### PR TITLE
Fix duplicative PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## Description
+
+Brief description of the changes.
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+
+## Related Issues
+
+Fixes #(issue number)
+
+## Checklist
+
+- [ ] My code follows the project's coding style
+- [ ] I have run `cargo fmt` and `cargo clippy`
+- [ ] I have added tests that prove my fix/feature works
+- [ ] All new and existing tests pass (`cargo test --features test-utils`)
+- [ ] I have updated documentation as needed
+- [ ] I have updated CHANGELOG.md (for user-facing changes)
+
+## Testing
+
+Describe how you tested these changes.
+
+## Screenshots (if applicable)
+
+Add screenshots for UI changes.


### PR DESCRIPTION
## Description

When cloning this repository, I end up with a Git warning:

```
$ git clone https://github.com/bswinnerton/prefixd.git
Cloning into 'prefixd'...
remote: Enumerating objects: 1423, done.
remote: Counting objects: 100% (45/45), done.
remote: Compressing objects: 100% (19/19), done.
remote: Total 1423 (delta 37), reused 26 (delta 26), pack-reused 1378 (from 3)
Receiving objects: 100% (1423/1423), 1.03 MiB | 9.69 MiB/s, done.
Resolving deltas: 100% (774/774), done.
warning: the following paths have collided (e.g. case-sensitive paths
on a case-insensitive filesystem) and only one from the same
colliding group is in the working tree:

  '.github/PULL_REQUEST_TEMPLATE.md'
  '.github/pull_request_template.md'
```

This pull request removes the lower cased template in favor of the upper cased one (though I'm not actually sure which is preferred; it looks like they were added around the same time).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

N/A

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have run `cargo fmt` and `cargo clippy`
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (`cargo test --features test-utils`)
- [ ] I have updated documentation as needed
- [ ] I have updated CHANGELOG.md (for user-facing changes)

## Testing

N/A

## Screenshots (if applicable)

N/A