### PR TITLE
Make POPs load dynamically in dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dashboard POP Selector** - POP dropdown in TopBar now loads dynamically from the backend API
+  - Replaced hardcoded POP list with `usePops()` and `useHealth()` hooks
+  - Current POP from health endpoint used as default selection
+- **`GET /v1/pops` Endpoint** - Current instance POP now always included in response
+  - Newly deployed POPs with no mitigations are no longer invisible to the API
+
 ### Added
 
 - **Juniper cJunosEvolved FlowSpec Lab** - End-to-end verified with real Junos router

--- a/frontend/components/dashboard/top-bar.tsx
+++ b/frontend/components/dashboard/top-bar.tsx
@@ -6,8 +6,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { ConnectionStatus } from "@/components/connection-status"
 import { UserMenu } from "@/components/user-menu"
 import { useWebSocket } from "@/hooks/use-websocket"
-
-const pops = ["IAD1", "IAD2", "SFO1", "LAX1", "ORD1", "AMS1", "FRA1", "NRT1"]
+import { usePops, useHealth } from "@/hooks/use-api"
 
 interface TopBarProps {
   onMenuClick?: () => void
@@ -17,6 +16,11 @@ interface TopBarProps {
 export function TopBar({ onMenuClick, onSearchClick }: TopBarProps) {
   const [time, setTime] = useState<string>("")
   const { connectionState } = useWebSocket()
+  const { data: popsData } = usePops()
+  const { data: health } = useHealth()
+
+  const currentPop = health?.pop?.toUpperCase()
+  const pops = popsData?.map((p) => p.pop.toUpperCase()) ?? (currentPop ? [currentPop] : [])
 
   useEffect(() => {
     const updateTime = () => {
@@ -52,9 +56,9 @@ export function TopBar({ onMenuClick, onSearchClick }: TopBarProps) {
           </div>
         </div>
 
-        <Select defaultValue="IAD1">
+        <Select defaultValue={currentPop}>
           <SelectTrigger className="w-20 h-7 bg-secondary border-border text-xs font-mono">
-            <SelectValue />
+            <SelectValue placeholder={currentPop ?? "..."} />
           </SelectTrigger>
           <SelectContent>
             {pops.map((pop) => (


### PR DESCRIPTION
## Description

The `TopBar`'s PoP selector was hardcoded with a static list of PoPs instead of loading them dynamically from the backend API. 

This pull request does two things to dynamically load the correct PoPs:
1. Updates the component to use the existing `usePops` React hook
2. Updates the `/v1/pops` endpoint to always include the current instance's PoP, even before the first mitigation is added

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

N/A

## Checklist

- [x] My code follows the project's coding style
- [x] I have run `cargo fmt` and `cargo clippy`
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`cargo test --features test-utils`)
- [ ] I have updated documentation as needed
- [x] I have updated CHANGELOG.md (for user-facing changes)

## Testing

By running the server locally, as well as running the tests. Three unit tests added for the `list_pops` current-PoP inclusion logic:
- `test_list_pops_includes_current_pop_when_missing` - verifies a new PoP with no mitigations is inserted in sorted order
- `test_list_pops_does_not_duplicate_existing_pop` - verifies an existing PoP is not duplicated
- `test_list_pops_inserts_into_empty_list` - verifies behavior when the database has no mitigations at all

## Screenshots (if applicable)

N/A