### PR TITLE
Add support for NEXT_PUBLIC_PREFIXD_WS frontend build argument

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,6 +12,10 @@ RUN bun install
 # Copy source
 COPY . .
 
+# Build arguments
+ARG NEXT_PUBLIC_PREFIXD_WS
+ENV NEXT_PUBLIC_PREFIXD_WS=$NEXT_PUBLIC_PREFIXD_WS
+
 # Build
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN bun run build


### PR DESCRIPTION
## Description

This pull request updates the frontend's Dockerfile to allow the websocket URL (`NEXT_PUBLIC_PREFIXD_WS`) to be set at build time instead of falling back to its default of localhost.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

- [ ] I have added tests that prove my fix/feature works
- [x] All existing tests pass locally (`cargo test --all-features`)
- [x] I have tested against a real GoBGP instance (if BGP-related)

## Checklist

- [x] My code follows the project's coding style
- [x] I have updated documentation as needed
- [x] I have not committed any secrets or credentials
- [x] My changes do not introduce new warnings (`cargo clippy`)

## Related Issues

N/A - Enhancement for deployment flexibility
