### PR TITLE
Use BGP session state for web UI

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -132,9 +132,10 @@ async function doFetch<T>(url: string, options: RequestInit): Promise<T> {
 
 export async function getHealth(): Promise<HealthResponse> {
   const data = await fetchApi<Omit<HealthResponse, 'bgp_session_up'>>("/v1/health")
+  const sessions = Object.values(data.bgp_sessions ?? {})
   return {
     ...data,
-    bgp_session_up: data.gobgp?.status === "connected",
+    bgp_session_up: sessions.length > 0 && sessions.every((s) => s === "established"),
   }
 }
 


### PR DESCRIPTION
## Description

The current BGP check that appears in the web UI checks to see if the gRPC connection to GoBGP is reachable, not necessarily whether all configured BGP sessions are actually in an established state.

This pull request updates the API to instead return true if all configured BGP sessions are up and established.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Related Issues



## Checklist

- [x] My code follows the project's coding style
- [x] I have run `cargo fmt` and `cargo clippy`
- [ ] I have added tests that prove my fix/feature works

Given the API is stable, I didn't opt for this, but am happy to add tests if that would be helpful

- [x] All new and existing tests pass (`cargo test --features test-utils`)
- [ ] I have updated documentation as needed
- [ ] I have updated CHANGELOG.md (for user-facing changes)

## Testing



## Screenshots (if applicable)

N/A
