### PR TITLE
feat: generic webhook adapter for arbitrary detectors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ src/
 ├── auth/              # AuthBackend (axum-login), mode-aware auth (none/bearer/credentials/mtls)
 ├── bgp/               # FlowSpecAnnouncer trait, GoBGP gRPC client, mock
 ├── config/            # Settings, Inventory, Playbooks (YAML parsing)
-├── correlation/       # Multi-signal correlation engine (config, engine, signal groups)
+├── correlation/       # Multi-signal correlation engine (config, engine, signal groups, webhook adapter)
 ├── db/                # PostgreSQL repository with sqlx + MockRepository for testing
 ├── domain/            # Core types: AttackEvent, Mitigation, FlowSpecRule
 ├── guardrails/        # Validation, quotas, safelist protection
@@ -164,6 +164,7 @@ See `docs/adr/` for all 19 Architecture Decision Records.
 - `GET /v1/signal-groups/{id}` - Signal group detail with contributing events
 - `POST /v1/signals/alertmanager` - Alertmanager webhook adapter (v4 payload)
 - `POST /v1/signals/fastnetmon` - FastNetMon webhook adapter (native JSON)
+- `POST /v1/signals/webhook/{name}` - Generic webhook adapter (configured in `correlation.yaml`; JSONPath field mapping; HMAC/bearer/none auth)
 - `GET /v1/config/correlation` - Correlation config (admin, secrets redacted)
 - `PUT /v1/config/correlation` - Update correlation config (admin only, writes YAML + hot-reload)
 
@@ -254,8 +255,8 @@ Completed:
 - Nginx reverse proxy (single-origin deployment)
 - ErrorBoundary wrapping all dashboard pages
 - Cross-entity navigation (command palette → detail pages, event↔mitigation linking, audit log → mitigations, clickable stat cards)
-- Multi-signal correlation engine with signal groups, Alertmanager and FastNetMon adapters
-- 19 Architecture Decision Records
+- Multi-signal correlation engine with signal groups, Alertmanager/FastNetMon adapters, and a generic JSONPath-driven webhook adapter (ADR 020)
+- 20 Architecture Decision Records
 - CLI tool (prefixdctl) for all API operations
 - OpenAPI spec with utoipa annotations
 - 179 backend unit tests + 99 integration + 16 postgres tests (+ 17 ignored requiring GoBGP/Docker)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to prefixd will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Generic webhook adapter** — Integrate any detector or telemetry source that can POST JSON without writing Rust. Configure a named adapter in `correlation.yaml` with JSONPath field mappings, HMAC/bearer/none auth, optional batching via `root_path`, vector normalization, and confidence scaling. Events flow through the standard correlation and policy pipeline. New endpoint: `POST /v1/signals/webhook/{name}`. See `docs/configuration.md` for the schema and `docs/api.md` for usage.
+
 ## [0.14.1] - 2026-04-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,6 +1631,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1841,6 +1850,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,6 +1871,16 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -2235,9 +2260,11 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
+ "serde_json_path",
  "serde_yaml",
  "sha2",
  "sqlx",
+ "subtle",
  "tempfile",
  "testcontainers",
  "testcontainers-modules",
@@ -2994,6 +3021,56 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_json_path"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b992cea3194eea663ba99a042d61cea4bd1872da37021af56f6a37e0359b9d33"
+dependencies = [
+ "inventory",
+ "nom",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_json_path_core",
+ "serde_json_path_macros",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "serde_json_path_core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde67d8dfe7d4967b5a95e247d4148368ddd1e753e500adb34b3ffe40c6bc1bc"
+dependencies = [
+ "inventory",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "serde_json_path_macros"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "517acfa7f77ddaf5c43d5f119c44a683774e130b4247b7d3210f8924506cfac8"
+dependencies = [
+ "inventory",
+ "serde_json_path_core",
+ "serde_json_path_macros_internal",
+]
+
+[[package]]
+name = "serde_json_path_macros_internal"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aafbefbe175fa9bf03ca83ef89beecff7d2a95aaacd5732325b90ac8c3bd7b90"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,8 @@ chrono = { version = "0.4", features = ["serde"] }
 sha2 = "0.10"
 hmac = "0.12"
 hex = "0.4"
+subtle = "2"
+serde_json_path = "0.7"
 ipnet = { version = "2", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env"] }
 async-trait = "0.1"

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,6 +23,7 @@ Any system that can POST JSON works. Tested with:
 - **FastNetMon Community** - Notify script integration ([setup guide](docs/detectors/fastnetmon.md))
 - **FastNetMon** (native webhook) - `POST /v1/signals/fastnetmon` accepts FastNetMon's JSON payload directly, classifies vector from traffic breakdown, configurable confidence mapping
 - **Prometheus/Alertmanager** - `POST /v1/signals/alertmanager` accepts Alertmanager v4 webhook payloads, maps labels/annotations to event fields, handles batched alerts with per-alert results
+- **Generic webhook adapter** - `POST /v1/signals/webhook/{name}` for detectors without a native adapter. Configured per-adapter in `correlation.yaml` with JSONPath field mappings, HMAC-SHA256 / bearer / none authentication, optional array batching via `root_path`, vector normalization, and confidence scaling. See ADR 020 and [docs/detectors/generic-webhook.md](docs/detectors/generic-webhook.md).
 - **Custom scripts** - Simple curl calls to `POST /v1/events`
 
 ### Event Schema

--- a/README.md
+++ b/README.md
@@ -170,6 +170,21 @@ curl -X POST http://localhost/v1/events \
 - **Alertmanager** → `POST /v1/signals/alertmanager` — maps labels/annotations to events
 - **FastNetMon** → `POST /v1/signals/fastnetmon` — accepts native JSON payload
 
+**Generic webhook adapter** — For detectors without a native integration (commercial DDoS appliances, internal abuse systems, cloud alerting), configure a named adapter in `correlation.yaml` with JSONPath field mappings:
+
+```yaml
+webhook_adapters:
+  - name: radware
+    auth: { type: hmac, secret_env: RADWARE_WEBHOOK_SECRET, header: X-Signature-SHA256, algorithm: sha256 }
+    root_path: "$.alerts[*]"
+    fields:
+      victim_ip: "$.target.ip"
+      vector: "$.alert_type"
+      bps: "$.traffic.bps"
+```
+
+POST your JSON to `/v1/signals/webhook/{name}`. See [Generic Webhook Adapter](docs/detectors/generic-webhook.md).
+
 With [multi-signal correlation](docs/configuration.md#correlation) enabled, events from multiple detectors targeting the same IP are grouped and corroborated before triggering mitigation.
 
 See [FastNetMon Integration](docs/detectors/fastnetmon.md) for a complete setup guide.
@@ -184,7 +199,7 @@ Configure GoBGP neighbors in `configs/gobgp.conf` and set up FlowSpec import pol
 
 | Category | What it does |
 |----------|--------------|
-| **Signal Ingestion** | HTTP API + native Alertmanager and FastNetMon webhook adapters |
+| **Signal Ingestion** | HTTP API + native Alertmanager and FastNetMon webhooks + configurable generic webhook adapter with JSONPath mapping |
 | **Multi-Signal Correlation** | Time-windowed grouping of events from multiple detectors with source weighting and corroboration |
 | **Policy Engine** | YAML playbooks define per-vector responses with escalation |
 | **Guardrails** | Quotas, safelist, /32-only enforcement, mandatory TTLs |
@@ -200,7 +215,7 @@ Configure GoBGP neighbors in `configs/gobgp.conf` and set up FlowSpec import pol
 
 ## How It Works
 
-1. **Detector sends event** → `POST /v1/events`, `/v1/signals/alertmanager`, or `/v1/signals/fastnetmon`
+1. **Detector sends event** → `POST /v1/events`, `/v1/signals/alertmanager`, `/v1/signals/fastnetmon`, or a configured `/v1/signals/webhook/{name}`
 2. **Inventory lookup** → Find customer/service owning the IP
 3. **Signal correlation** → Group related signals by (victim_ip, vector), check corroboration
 4. **Playbook match** → Determine action (police/discard) based on vector

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -278,7 +278,9 @@ Example: FastNetMon says UDP flood at 0.6 confidence + router CPU spiking + host
 
 - [x] Prometheus/Alertmanager adapter (`POST /v1/signals/alertmanager` webhook receiver) — maps labels/annotations to attack events, handles batched alerts
 - [x] FastNetMon webhook adapter (`POST /v1/signals/fastnetmon`) — classifies vectors from traffic breakdown, configurable confidence mapping
+- [x] Generic webhook adapter (`POST /v1/signals/webhook/{name}`) — operator-configured JSONPath mapping, HMAC/bearer/none auth, array batching via root_path (ADR 020)
 - [ ] Router telemetry adapter (JTI, gNMI)
+- [ ] Generic adapter transform functions (unit conversion, regex extract, computed fields)
 
 ### Correlation Engine
 
@@ -303,8 +305,9 @@ Broader ecosystem integration and advanced capabilities for large-scale deployme
 ### Integrations
 
 - [ ] NetBox inventory sync (replace YAML inventory with NetBox as source-of-truth)
-- [ ] FastNetMon native adapter (common pairing for self-hosted deployments)
+- [x] FastNetMon native adapter (common pairing for self-hosted deployments) — shipped v0.14.0
 - [ ] Scrubber vendor integrations (complement cloud/hardware mitigation with policy automation)
+- [ ] Reference integration recipes for commercial DDoS appliances (Radware, NETSCOUT, A10) via the generic webhook adapter
 - [ ] LDAP/AD auth backend (group-to-role mapping)
 - [ ] RADIUS/ISE auth backend (attribute mapping to roles)
 - [ ] Customer self-service portal (per-customer dashboards for MSSPs)

--- a/configs/correlation.yaml
+++ b/configs/correlation.yaml
@@ -16,3 +16,39 @@ sources:
     type: telemetry
     confidence_mapping: {}
 default_weight: 1.0
+
+# Generic webhook adapters. Each entry becomes a named endpoint at
+# POST /v1/signals/webhook/{name} and maps an arbitrary JSON payload into an
+# AttackEvent via JSONPath expressions.
+#
+# See docs/configuration.md for the full schema and field reference.
+#
+# Example (disabled by default):
+# webhook_adapters:
+#   - name: example-detector
+#     description: Example generic detector integration
+#     enabled: false
+#     auth:
+#       type: hmac                        # hmac | bearer | none
+#       secret_env: EXAMPLE_WEBHOOK_SECRET
+#       header: X-Signature-SHA256
+#       algorithm: sha256
+#     # root_path iterates an array of alerts in one payload (omit for single-event POSTs)
+#     root_path: "$.alerts[*]"
+#     fields:
+#       victim_ip: "$.target.ip"          # REQUIRED
+#       vector: "$.alert_type"            # optional; falls back to default_vector
+#       timestamp: "$.time"               # optional; RFC3339 string expected
+#       bps: "$.traffic.bps"              # optional
+#       pps: "$.traffic.pps"              # optional
+#       confidence: "$.score"             # optional; see confidence_scale
+#       source_id: "$.id"                 # optional; used for dedup
+#       top_dst_ports: "$.ports"          # optional; array of port numbers
+#       action: "$.action"                # optional; "ban" (default) or "unban"
+#     vector_map:
+#       UDP_FLOOD: udp_flood
+#       SYN_FLOOD: syn_flood
+#       TCP_SYN: syn_flood
+#     default_vector: unknown
+#     confidence_scale: 100               # divide extracted score by this (for 0-100 scales)
+#     source_id_prefix: "example-"

--- a/docs/adr/020-generic-webhook-adapter.md
+++ b/docs/adr/020-generic-webhook-adapter.md
@@ -1,0 +1,116 @@
+# ADR 020: Generic Webhook Adapter
+
+## Status
+
+Accepted
+
+## Date
+
+2026-04-18
+
+## Context
+
+ADR 019 established a pattern of dedicated signal-adapter endpoints per detector, with the first two being Alertmanager (`/v1/signals/alertmanager`) and FastNetMon (`/v1/signals/fastnetmon`). Each native adapter is 150-300 LOC of Rust: payload structs, label mapping, confidence heuristics, integration tests.
+
+That pattern works well for systems prefixd will be tightly coupled to, but it doesn't scale to the long tail of detectors — internal abuse systems, commercial DDoS appliances (Radware, NETSCOUT, A10), cloud platforms (GCP Cloud Armor, AWS Shield events), and bespoke signal pipelines. Operators shouldn't have to fork prefixd to wire in a new detector that speaks JSON.
+
+Key questions:
+
+1. **How does an operator integrate a new detector without touching Rust?**
+2. **What mapping language do we use?** JSONPath, JMESPath, dotted paths, custom DSL?
+3. **How is authentication configured per adapter?** Bearer token alone is weak for webhooks; most mature systems expect HMAC.
+4. **How do we keep configuration safe?** YAML secrets are dangerous; the API must not leak shared secrets.
+5. **How does batching work?** Many detectors POST an array of alerts in a single request (like Alertmanager's native format).
+6. **What happens to the existing Alertmanager/FastNetMon adapters?** Do we migrate them to the generic pattern, keep them separate, or both?
+
+## Decision
+
+### Configuration-driven adapters in `correlation.yaml`
+
+Webhook adapters are declared in the existing `correlation.yaml`, alongside other correlation-engine configuration:
+
+```yaml
+webhook_adapters:
+  - name: radware
+    enabled: true
+    auth:
+      type: hmac
+      secret_env: RADWARE_WEBHOOK_SECRET
+      header: X-Signature-SHA256
+      algorithm: sha256
+    root_path: "$.alerts[*]"
+    fields:
+      victim_ip: "$.target.ip"
+      vector: "$.alert_type"
+      bps: "$.traffic.bps"
+      confidence: "$.score"
+    vector_map:
+      UDP_FLOOD: udp_flood
+    default_vector: unknown
+    confidence_scale: 100
+```
+
+Each adapter becomes reachable at `POST /v1/signals/webhook/{name}`, where `name` is an operator-chosen segment matching `[a-z0-9-]{1,64}`. The handler compiles the JSONPath expressions at resolution time, verifies authentication, parses the body, and feeds each mapped event through the standard `handle_ban` / `handle_unban` pipeline — identical to every other signal adapter.
+
+### JSONPath for field mapping (RFC 9535)
+
+We chose **JSONPath** over alternatives:
+
+| Language | Pros | Cons |
+|---|---|---|
+| **JSONPath** (chosen) | RFC 9535 standardized, widely recognized (Kubernetes, Splunk, Prometheus), mature Rust crate (`serde_json_path`), handles arrays/filters | Non-trivial syntax (`$.a[*].b`) |
+| Dotted paths (e.g. `a.b.c`) | Minimal dependency, simple | No array iteration, no filters, operators will outgrow it quickly |
+| JMESPath | Also standardized, good Rust support | Less familiar outside AWS ecosystem |
+| Custom DSL | Full control | Yet another syntax for operators to learn; no ecosystem |
+
+JSONPath strikes the right balance: operators already know it from Kubernetes, it handles the common "array of alerts in one webhook" shape via `root_path: "$.alerts[*]"`, and `serde_json_path` is pure Rust with no C dependencies.
+
+### Three authentication modes per adapter
+
+- **`hmac`** (recommended) — HMAC-SHA256 over the raw request body. Secret loaded from an environment variable named in `auth.secret_env`; the secret is never embedded in YAML, never returned from the API, and never logged. Comparison is constant-time via the `subtle` crate. The hex digest may be prefixed with `sha256=` (GitHub-style).
+- **`bearer`** — Reuses the global session / bearer backend. Convenient when the detector can already authenticate as an operator.
+- **`none`** — No authentication. Intended for lab or trusted-network use; logged with a warning at startup.
+
+Per-adapter auth was chosen over a single global scheme because mature webhook producers (GitHub, Stripe, Radware, etc.) overwhelmingly use HMAC, but internal detectors often only know how to send a bearer token.
+
+### Secret handling
+
+Secrets are **only** loaded from environment variables referenced by `auth.secret_env`. The YAML file carries the env-var name, not the secret itself. The config API (`GET /v1/config/correlation`) returns the env-var name; the secret value is neither readable via the API nor written to any audit log.
+
+### Endpoint shape: `/v1/signals/webhook/{name}`
+
+We chose a name-keyed endpoint rather than a single `/v1/signals/webhook` with an adapter-identifier in the payload or a query string. Reasons:
+
+- **Discoverability** — Each adapter has a stable URL that operators can configure in detector UIs.
+- **Observability** — Metrics and access logs naturally group by adapter path.
+- **Validation** — Name is validated against `[a-z0-9-]{1,64}` on the hot path, preventing any path-traversal or injection. Unknown / disabled names return 404.
+
+### No migration of existing adapters
+
+Alertmanager and FastNetMon adapters keep their dedicated endpoints and Rust code. Their payloads have source-specific semantics (Alertmanager's `status: resolved` → unban, FastNetMon's `action: ban/partial_block/alert` → confidence mapping) that would be awkward to express purely through JSONPath. The generic adapter is for *new* integrations; the native adapters remain the reference for deeply-integrated detectors.
+
+### Batching via `root_path`
+
+When `root_path` is set, the JSONPath is evaluated against the payload and each matching node becomes one `AttackEventInput`. This mirrors how Alertmanager ships N alerts per webhook. Partial failures are reported per-event in the response (same shape as the Alertmanager handler); the overall HTTP status is 200 for well-formed payloads so the sender doesn't retry the whole batch.
+
+## Consequences
+
+### Positive
+
+- **New integrations without a Rust change** — Operators add a `webhook_adapters` entry, reload config, and start sending events. No PR, no rebuild.
+- **Covers the long tail** — Commercial appliances, internal tools, and cloud alerting all share the same mental model.
+- **Reuses the existing pipeline** — Guardrails, correlation, policy, BGP, audit: all identical to other adapters.
+- **Safe by default** — Name validation prevents URL abuse; HMAC is the documented default; constant-time compare; secrets never leave the environment.
+- **Tested** — 13 unit tests (mapping, HMAC) + 11 integration tests (happy path, auth, batching, failures) on the first cut.
+
+### Negative
+
+- **Less type safety than native adapters** — A malformed payload shape produces a 400 or a per-event error result instead of a compile-time check. Mitigated by tests and by validating JSONPath expressions at config load.
+- **Operators must understand JSONPath** — Documented with examples in `docs/configuration.md`; most operators already know the basics from Kubernetes.
+- **No transform functions yet** — Unit conversion, regex extraction, and computed fields are not supported. Deferred to a follow-up; most detectors already emit numeric values and vector strings that the mapping can pass through directly.
+
+### Neutral
+
+- **Adapter weight registration** — For correlation weighting, operators add the adapter's name to the existing `sources:` map. Unlisted adapters fall back to `default_weight`.
+- **HMAC algorithm fixed at SHA-256** — SHA-512 / Blake3 can be added later without breaking the config schema (extend the `algorithm` enum).
+- **Adapters are hot-reloadable** — Changes to `webhook_adapters` take effect on `POST /v1/config/reload`, same as sources and playbooks.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,5 +27,6 @@ Format follows [Michael Nygard's template](https://cognitect.com/blog/2011/11/15
 | [017](017-notification-routing-preferences.md) | Per-Destination Event Routing and Notification Preferences | Accepted | 2026-03-18 |
 | [018](018-multi-signal-correlation-engine.md) | Multi-Signal Correlation Engine | Accepted | 2026-03-19 |
 | [019](019-signal-adapter-architecture.md) | Signal Adapter Architecture | Accepted | 2026-03-19 |
+| [020](020-generic-webhook-adapter.md) | Generic Webhook Adapter | Accepted | 2026-04-18 |
 
 ADRs are numbered sequentially as written. Retroactive ADRs (009-013) were documented on 2026-02-18 but dated to when the decision was originally made.

--- a/docs/api.md
+++ b/docs/api.md
@@ -835,6 +835,72 @@ notify_script_path = /usr/bin/curl -s -X POST http://prefixd.example.com/v1/sign
 
 See `docs/detectors/fastnetmon.md` for a complete integration guide.
 
+### Generic Webhook Adapter
+
+For detectors without a native adapter, configure a generic webhook adapter in
+`correlation.yaml` and POST arbitrary JSON. Fields are extracted via JSONPath.
+
+```http
+POST /v1/signals/webhook/{name}
+Content-Type: application/json
+X-Signature-SHA256: <hex-encoded HMAC-SHA256 of request body>
+
+<any JSON payload matching the adapter's field mappings>
+```
+
+**Path parameter:**
+
+- `name` — Must match a `webhook_adapters[].name` entry in `correlation.yaml`. Names are restricted to `[a-z0-9-]{1,64}`.
+
+**Authentication:**
+
+- `hmac` — HMAC-SHA256 over the raw request body. Header name is configurable (default `X-Signature-SHA256`). The hex digest may be prefixed with `sha256=` (GitHub-style). Secret is read from the env var named in `auth.secret_env`.
+- `bearer` — Reuses the global session/bearer auth backend.
+- `none` — No auth enforced (intended for lab use only).
+
+**Response:**
+
+```json
+{
+  "processed": 2,
+  "failed": 0,
+  "results": [
+    { "index": 0, "status": "mitigated", "event_id": "…", "mitigation_id": "…" },
+    { "index": 1, "status": "duplicate" }
+  ]
+}
+```
+
+**Configuration example** (`configs/correlation.yaml`):
+
+```yaml
+webhook_adapters:
+  - name: radware
+    enabled: true
+    auth:
+      type: hmac
+      secret_env: RADWARE_WEBHOOK_SECRET
+      header: X-Signature-SHA256
+      algorithm: sha256
+    root_path: "$.alerts[*]"
+    fields:
+      victim_ip: "$.target.ip"
+      vector: "$.alert_type"
+      timestamp: "$.time"
+      bps: "$.metrics.bps"
+      pps: "$.metrics.pps"
+      confidence: "$.score"
+      source_id: "$.id"
+    vector_map:
+      UDP_FLOOD: udp_flood
+      SYN_FLOOD: syn_flood
+    default_vector: unknown
+    confidence_scale: 100
+    source_id_prefix: "radware-"
+```
+
+See `docs/configuration.md` for the complete schema.
+
 ---
 
 ## Safelist

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -354,6 +354,89 @@ When a playbook has no `correlation` override, the global defaults from `prefixd
 
 Correlation config changes take effect on `POST /v1/config/reload` without restart (same as inventory and playbooks).
 
+#### Generic Webhook Adapters
+
+For detection or telemetry systems without a native adapter (Alertmanager, FastNetMon), configure a generic webhook adapter. Each entry becomes a new endpoint at `POST /v1/signals/webhook/{name}` that accepts arbitrary JSON and maps it to an `AttackEvent` via JSONPath.
+
+```yaml
+correlation:
+  webhook_adapters:
+    - name: radware                       # URL-safe: [a-z0-9-]{1,64}
+      description: "Radware DefensePro"
+      enabled: true
+      auth:
+        type: hmac                        # hmac | bearer | none
+        secret_env: RADWARE_WEBHOOK_SECRET
+        header: X-Signature-SHA256
+        algorithm: sha256                 # sha256 only in v1
+      root_path: "$.alerts[*]"            # optional: iterate an array
+      fields:
+        victim_ip: "$.target.ip"          # REQUIRED
+        vector: "$.alert_type"
+        timestamp: "$.time"
+        bps: "$.traffic.bps"
+        pps: "$.traffic.pps"
+        confidence: "$.score"
+        source_id: "$.id"
+        top_dst_ports: "$.ports"
+        action: "$.action"                # "ban" (default) or "unban"
+      vector_map:                         # normalize detector strings
+        UDP_FLOOD: udp_flood
+        SYN_FLOOD: syn_flood
+      default_vector: unknown
+      confidence_scale: 100               # divide extracted value by this
+      source_id_prefix: "radware-"
+```
+
+**Adapter schema:**
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `name` | yes | string | URL path segment, `[a-z0-9-]{1,64}` |
+| `description` | no | string | Human-readable label |
+| `enabled` | no | boolean (default `true`) | Disabled adapters return 404 |
+| `auth` | yes | object | Authentication scheme (see below) |
+| `root_path` | no | JSONPath | When set, each match produces one event |
+| `fields.victim_ip` | yes | JSONPath | String extraction; must parse as an IP |
+| `fields.vector` | no | JSONPath | String; normalized via `vector_map` + `default_vector` |
+| `fields.timestamp` | no | JSONPath | RFC 3339 string; defaults to receive time |
+| `fields.bps` / `fields.pps` | no | JSONPath | Numbers |
+| `fields.confidence` | no | JSONPath | Number; scaled via `confidence_scale`, clamped to `[0,1]` |
+| `fields.source_id` | no | JSONPath | String/number; becomes `event_id` with optional prefix |
+| `fields.top_dst_ports` | no | JSONPath | Array of port numbers |
+| `fields.action` | no | JSONPath | `ban` (default) or `unban` |
+| `vector_map` | no | map | Raw detector string → prefixd vector name |
+| `default_vector` | no | string | Fallback when vector missing or not in map |
+| `confidence_scale` | no | float | Divisor (e.g. `100` for 0–100 scales) |
+| `source_id_prefix` | no | string | Prefix prepended to extracted `source_id` |
+
+**Authentication:**
+
+| `auth.type` | Meaning |
+|-------------|---------|
+| `hmac` | HMAC-SHA256 over the raw body. `auth.header` is the request header (default `X-Signature-SHA256`). `auth.secret_env` is the env var holding the secret. Comparison is constant-time. Hex digest may be prefixed with `sha256=`. |
+| `bearer` | Reuses global session/bearer auth. |
+| `none` | No auth (lab use only). |
+
+**JSONPath quick reference** (RFC 9535 via `serde_json_path`):
+
+- `$.field` — root field lookup
+- `$.a.b.c` — nested lookup
+- `$.items[0]` — array index
+- `$.items[*]` — array iteration (only meaningful as `root_path`)
+- `$.items[?(@.severity=="high")]` — filter expression
+
+**Weighting:** To weight a webhook adapter's events in correlation, register its name in `sources:` alongside detector/alertmanager:
+
+```yaml
+sources:
+  radware:
+    weight: 1.2
+    type: detector
+```
+
+Adapters not listed fall back to `default_weight`.
+
 ### Shutdown
 
 ```yaml

--- a/docs/detectors/generic-webhook.md
+++ b/docs/detectors/generic-webhook.md
@@ -28,46 +28,66 @@ openssl rand -hex 32   # 64-character hex string
 
 The secret must be present at prefixd startup; it is read from the environment, **not** from YAML. The API will never return it.
 
-### 2. Add the adapter to `correlation.yaml`
+### 2. Add the adapter to the correlation config
+
+prefixd accepts correlation config in two layouts (either is fine; the standalone file takes precedence when both exist):
+
+- **Standalone `configs/correlation.yaml`** (recommended) — top-level keys directly, no wrapping `correlation:` section.
+- **Embedded in `configs/prefixd.yaml`** — nested under a `correlation:` key alongside other daemon settings.
+
+**Standalone `configs/correlation.yaml`:**
+
+```yaml
+enabled: true
+# … your existing correlation settings …
+
+sources:
+  radware:
+    weight: 1.2
+    type: detector
+
+webhook_adapters:
+  - name: radware
+    description: "Radware DefensePro alert stream"
+    enabled: true
+    auth:
+      type: hmac
+      secret_env: RADWARE_WEBHOOK_SECRET
+      header: X-Signature-SHA256
+      algorithm: sha256
+    root_path: "$.alerts[*]"
+    fields:
+      victim_ip: "$.target.ip"
+      vector: "$.alert_type"
+      timestamp: "$.time"
+      bps: "$.traffic.bps"
+      pps: "$.traffic.pps"
+      confidence: "$.score"
+      source_id: "$.id"
+      top_dst_ports: "$.ports"
+      action: "$.action"
+    vector_map:
+      UDP_FLOOD: udp_flood
+      SYN_FLOOD: syn_flood
+      DNS_AMP: dns_amp
+      NTP_AMP: ntp_amp
+    default_vector: unknown
+    confidence_scale: 100
+    source_id_prefix: "radware-"
+```
+
+**Embedded in `configs/prefixd.yaml`** (same fields, one level deeper):
 
 ```yaml
 correlation:
   enabled: true
-  # … your existing correlation settings …
-
   sources:
     radware:
       weight: 1.2
       type: detector
-
   webhook_adapters:
     - name: radware
-      description: "Radware DefensePro alert stream"
-      enabled: true
-      auth:
-        type: hmac
-        secret_env: RADWARE_WEBHOOK_SECRET
-        header: X-Signature-SHA256
-        algorithm: sha256
-      root_path: "$.alerts[*]"
-      fields:
-        victim_ip: "$.target.ip"
-        vector: "$.alert_type"
-        timestamp: "$.time"
-        bps: "$.traffic.bps"
-        pps: "$.traffic.pps"
-        confidence: "$.score"
-        source_id: "$.id"
-        top_dst_ports: "$.ports"
-        action: "$.action"
-      vector_map:
-        UDP_FLOOD: udp_flood
-        SYN_FLOOD: syn_flood
-        DNS_AMP: dns_amp
-        NTP_AMP: ntp_amp
-      default_vector: unknown
-      confidence_scale: 100
-      source_id_prefix: "radware-"
+      # … same adapter fields as above
 ```
 
 Reload the config (no restart required):
@@ -155,10 +175,17 @@ The adapter uses RFC 9535 JSONPath (`serde_json_path`):
 | Symptom | Likely cause |
 |---|---|
 | HTTP 404 | Adapter name mismatch, or `enabled: false` |
-| HTTP 401 with `"signature mismatch"` | Shared secret differs between sender and `RADWARE_WEBHOOK_SECRET`, or the sender hashed a different byte range (e.g. after `Content-Encoding: gzip`) — ensure HMAC is computed over the raw request body prefixd receives |
-| HTTP 400 with `"victim_ip not found"` | JSONPath didn't match; verify with `jq` locally against a real payload |
+| HTTP 401 with `"missing HMAC signature header"` | Sender didn't include the signature header named in `auth.header` |
+| HTTP 401 with `"HMAC signature verification failed"` | Shared secret differs between sender and `RADWARE_WEBHOOK_SECRET`, or the sender hashed a different byte range (e.g. after `Content-Encoding: gzip`) — ensure HMAC is computed over the raw request body prefixd receives |
+| HTTP 400 with `"invalid JSON"` | Payload isn't valid JSON at all |
+| HTTP 400 with `"no events extracted from payload"` | `root_path` matched zero nodes — verify the expression against a real payload |
+| HTTP 200 with per-event `results[].status="error"` and `"required field 'victim_ip' missing from payload"` | JSONPath for `victim_ip` didn't match; verify with `jq` locally |
+| HTTP 200 with per-event `results[].status="error"` and `"invalid IP address"` | `victim_ip` extracted but didn't parse as an IP — check for port suffixes or extra whitespace |
+| HTTP 200 with per-event `results[].status="error"` and `"invalid value for field 'action'"` | Payload contained an `action` field with something other than `"ban"` or `"unban"` |
 | Events appear but `vector: unknown` | Raw vector string isn't in `vector_map`; add it, or accept `default_vector` |
 | Confidence always 1.0 | `confidence_scale` missing or mis-set; detectors that emit 0–100 need `confidence_scale: 100` |
+
+Mapping failures never fail the whole batch — they produce per-event `status: "error"` entries with the error message inline, and the overall HTTP status stays `200` so the sender doesn't retry valid events in the same payload.
 
 ## Promoting to a native adapter
 

--- a/docs/detectors/generic-webhook.md
+++ b/docs/detectors/generic-webhook.md
@@ -1,0 +1,165 @@
+# Generic Webhook Adapter
+
+The generic webhook adapter lets you integrate any detector or telemetry system that can POST JSON, without writing Rust code. You declare one or more named adapters in `correlation.yaml`, and each becomes a fully-authenticated endpoint at `POST /v1/signals/webhook/{name}` that feeds events into the standard correlation and mitigation pipeline.
+
+> For integrations that prefixd ships natively — Alertmanager, FastNetMon — use the dedicated endpoints (`/v1/signals/alertmanager`, `/v1/signals/fastnetmon`). The generic adapter is for everything else.
+
+## When to use it
+
+- Commercial DDoS appliances (Radware DefensePro, NETSCOUT Arbor, A10 Thunder)
+- Cloud alerting (GCP Cloud Armor, AWS Shield Advanced events, Cloudflare)
+- Internal abuse / anomaly-detection platforms that emit JSON webhooks
+- Quick prototyping of new signal sources before deciding whether they warrant a native adapter
+
+See ADR 020 for design rationale.
+
+## End-to-end example: Radware DefensePro
+
+This walkthrough integrates a hypothetical Radware DefensePro alert stream. Radware posts signed JSON with an HMAC-SHA256 signature in the `X-Signature-SHA256` header.
+
+### 1. Create the shared secret
+
+Generate a random HMAC key, store it wherever you already store prefixd secrets (Docker Compose env file, Kubernetes `Secret`, systemd `EnvironmentFile`, etc.), and export it as the environment variable you'll reference from `correlation.yaml`:
+
+```bash
+openssl rand -hex 32   # 64-character hex string
+# export RADWARE_WEBHOOK_SECRET="<paste>"
+```
+
+The secret must be present at prefixd startup; it is read from the environment, **not** from YAML. The API will never return it.
+
+### 2. Add the adapter to `correlation.yaml`
+
+```yaml
+correlation:
+  enabled: true
+  # … your existing correlation settings …
+
+  sources:
+    radware:
+      weight: 1.2
+      type: detector
+
+  webhook_adapters:
+    - name: radware
+      description: "Radware DefensePro alert stream"
+      enabled: true
+      auth:
+        type: hmac
+        secret_env: RADWARE_WEBHOOK_SECRET
+        header: X-Signature-SHA256
+        algorithm: sha256
+      root_path: "$.alerts[*]"
+      fields:
+        victim_ip: "$.target.ip"
+        vector: "$.alert_type"
+        timestamp: "$.time"
+        bps: "$.traffic.bps"
+        pps: "$.traffic.pps"
+        confidence: "$.score"
+        source_id: "$.id"
+        top_dst_ports: "$.ports"
+        action: "$.action"
+      vector_map:
+        UDP_FLOOD: udp_flood
+        SYN_FLOOD: syn_flood
+        DNS_AMP: dns_amp
+        NTP_AMP: ntp_amp
+      default_vector: unknown
+      confidence_scale: 100
+      source_id_prefix: "radware-"
+```
+
+Reload the config (no restart required):
+
+```bash
+curl -X POST -H "Authorization: Bearer $PREFIXD_API_TOKEN" http://prefixd.example.com/v1/config/reload
+```
+
+### 3. Configure Radware to POST
+
+Point Radware at:
+
+```
+POST https://prefixd.example.com/v1/signals/webhook/radware
+Content-Type: application/json
+X-Signature-SHA256: <hex HMAC-SHA256 of the raw body, computed with RADWARE_WEBHOOK_SECRET>
+```
+
+A sample payload, after Radware-side HMAC:
+
+```json
+{
+  "alerts": [
+    {
+      "id": "alert-12345",
+      "time": "2026-04-18T19:23:00Z",
+      "alert_type": "UDP_FLOOD",
+      "target": { "ip": "203.0.113.10" },
+      "traffic": { "bps": 1800000000, "pps": 1200000 },
+      "ports": [53, 123],
+      "score": 87,
+      "action": "ban"
+    }
+  ]
+}
+```
+
+prefixd resolves the mapping in order:
+
+1. **`root_path: "$.alerts[*]"`** iterates the array, producing one `AttackEventInput` per alert.
+2. **`fields.victim_ip: "$.target.ip"`** extracts the victim IP (relative to each alert node).
+3. **`vector_map`** translates `UDP_FLOOD` → `udp_flood` (falls back to `default_vector: unknown` if missing).
+4. **`confidence_scale: 100`** divides the extracted `score` (87) to produce `0.87`.
+5. **`source_id_prefix`** prepends `radware-` to `alert-12345` for the event ID.
+
+The adapter then calls the standard `handle_ban` path, which runs guardrails, correlation, and FlowSpec announcement exactly as if the event had come from the native API.
+
+### 4. Verify
+
+Tail the logs and look for `ingest_webhook` entries:
+
+```bash
+docker compose logs -f prefixd | grep webhook
+```
+
+Check the dashboard → Correlation → Signals tab. Events should appear with `source: radware`. If you've configured correlation weights, the adapter contributes at weight 1.2 per the `sources.radware` entry.
+
+## Schema reference
+
+See [configuration.md § Generic Webhook Adapters](../configuration.md#generic-webhook-adapters) for the complete field reference.
+
+## JSONPath cheat sheet
+
+The adapter uses RFC 9535 JSONPath (`serde_json_path`):
+
+| Expression | Meaning |
+|---|---|
+| `$.field` | Root-level field |
+| `$.a.b.c` | Nested field |
+| `$.items[0]` | Array index |
+| `$.items[*]` | Array iteration (use as `root_path`) |
+| `$.items[?(@.severity=="critical")]` | Filter expression |
+| `$.value \|\| 0` | ⚠️ Not supported — no fallback operator. Use `default_vector` / omit the field instead. |
+
+## Security
+
+- **HMAC is the default.** Bearer and none modes are offered for existing infrastructure where HMAC isn't available, but HMAC is strongly preferred for internet-reachable endpoints.
+- **Constant-time comparison.** Signature verification uses `subtle::ConstantTimeEq` to prevent timing oracles.
+- **Secrets never leave the environment.** The YAML carries the env-var name, not the value. `GET /v1/config/correlation` returns the env-var name only.
+- **Path validation.** The adapter name is validated against `[a-z0-9-]{1,64}` on every request, so path traversal and injection are not possible via the URL.
+- **Lab-only mode.** `auth.type: none` is allowed for lab setups but emits a warning at config-load time.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| HTTP 404 | Adapter name mismatch, or `enabled: false` |
+| HTTP 401 with `"signature mismatch"` | Shared secret differs between sender and `RADWARE_WEBHOOK_SECRET`, or the sender hashed a different byte range (e.g. after `Content-Encoding: gzip`) — ensure HMAC is computed over the raw request body prefixd receives |
+| HTTP 400 with `"victim_ip not found"` | JSONPath didn't match; verify with `jq` locally against a real payload |
+| Events appear but `vector: unknown` | Raw vector string isn't in `vector_map`; add it, or accept `default_vector` |
+| Confidence always 1.0 | `confidence_scale` missing or mis-set; detectors that emit 0–100 need `confidence_scale: 100` |
+
+## Promoting to a native adapter
+
+If a generic-adapter integration becomes critical and you need source-specific semantics (stateful unban logic, non-JSON payloads, per-detector validation), consider writing a native adapter — see ADR 019 for the architecture and `src/correlation/fastnetmon.rs` for a reference implementation.

--- a/frontend/__tests__/webhook-adapters.test.ts
+++ b/frontend/__tests__/webhook-adapters.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest"
+import { validateAdapter } from "@/components/dashboard/correlation/webhook-adapters"
+import type { WebhookAdapter } from "@/lib/api"
+
+function base(): WebhookAdapter {
+  return {
+    name: "radware",
+    description: "",
+    enabled: true,
+    auth: { type: "hmac", secret_env: "RADWARE_SECRET", header: "X-Signature-SHA256", algorithm: "sha256" },
+    root_path: null,
+    fields: {
+      victim_ip: "$.target.ip",
+      vector: null,
+      timestamp: null,
+      bps: null,
+      pps: null,
+      confidence: null,
+      source_id: null,
+      top_dst_ports: null,
+      action: null,
+    },
+    vector_map: {},
+    default_vector: null,
+    confidence_scale: null,
+    source_id_prefix: null,
+  }
+}
+
+describe("validateAdapter", () => {
+  it("returns no errors for a valid adapter", () => {
+    expect(validateAdapter(base(), [], true)).toEqual([])
+  })
+
+  it.each([
+    ["Upper"],
+    ["has space"],
+    ["has/slash"],
+    [""],
+    ["a".repeat(65)],
+  ])("rejects invalid name %s", (bad) => {
+    const adapter = { ...base(), name: bad }
+    const errors = validateAdapter(adapter, [], true)
+    expect(errors.some((e) => e.includes("name must match"))).toBe(true)
+  })
+
+  it("rejects duplicate name for new adapters", () => {
+    const errors = validateAdapter(base(), ["radware"], true)
+    expect(errors.some((e) => e.includes("already in use"))).toBe(true)
+  })
+
+  it("allows same name when editing existing adapter (isNew=false)", () => {
+    const errors = validateAdapter(base(), ["radware"], false)
+    expect(errors).toEqual([])
+  })
+
+  it("requires fields.victim_ip", () => {
+    const adapter = { ...base(), fields: { ...base().fields, victim_ip: "" } }
+    const errors = validateAdapter(adapter, [], true)
+    expect(errors).toContain("fields.victim_ip is required")
+  })
+
+  it("requires auth.secret_env when auth type is hmac", () => {
+    const adapter = base()
+    adapter.auth = { type: "hmac", secret_env: "", header: "X-Signature-SHA256", algorithm: "sha256" }
+    const errors = validateAdapter(adapter, [], true)
+    expect(errors).toContain("auth.secret_env is required for HMAC")
+  })
+
+  it("does not require secret_env when auth type is bearer", () => {
+    const adapter = { ...base(), auth: { type: "bearer" as const } }
+    const errors = validateAdapter(adapter, [], true)
+    expect(errors).toEqual([])
+  })
+
+  it("does not require secret_env when auth type is none", () => {
+    const adapter = { ...base(), auth: { type: "none" as const } }
+    const errors = validateAdapter(adapter, [], true)
+    expect(errors).toEqual([])
+  })
+
+  it("rejects confidence_scale <= 0", () => {
+    const adapter = { ...base(), confidence_scale: 0 }
+    const errors = validateAdapter(adapter, [], true)
+    expect(errors).toContain("confidence_scale must be > 0")
+  })
+
+  it("allows null confidence_scale", () => {
+    const adapter = { ...base(), confidence_scale: null }
+    const errors = validateAdapter(adapter, [], true)
+    expect(errors).toEqual([])
+  })
+})

--- a/frontend/components/dashboard/correlation/config-tab.tsx
+++ b/frontend/components/dashboard/correlation/config-tab.tsx
@@ -33,11 +33,14 @@ import type { CorrelationConfig, SourceConfig } from "@/lib/api"
 import { Settings, Plus, Pencil, Trash2, Save, Loader2, AlertCircle, Link as LinkIcon } from "lucide-react"
 import Link from "next/link"
 
+import { WebhookAdaptersEditor } from "./webhook-adapters"
+
 export function ConfigTab() {
   return (
     <div className="space-y-6">
       <CorrelationSettingsEditor />
       <SignalSourceCards />
+      <WebhookAdaptersEditor />
       <PlaybookOverrides />
     </div>
   )

--- a/frontend/components/dashboard/correlation/webhook-adapters.tsx
+++ b/frontend/components/dashboard/correlation/webhook-adapters.tsx
@@ -1,0 +1,695 @@
+"use client"
+
+import { useState, useCallback } from "react"
+import { toast } from "sonner"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { useCorrelationConfig } from "@/hooks/use-api"
+import { usePermissions } from "@/hooks/use-permissions"
+import { updateCorrelationConfig } from "@/lib/api"
+import type {
+  CorrelationConfig,
+  WebhookAdapter,
+  WebhookAuth,
+  WebhookFieldMap,
+} from "@/lib/api"
+import {
+  Webhook,
+  Plus,
+  Pencil,
+  Trash2,
+  Save,
+  Loader2,
+  AlertCircle,
+  Copy,
+} from "lucide-react"
+
+const NAME_PATTERN = /^[a-z0-9-]{1,64}$/
+
+export function WebhookAdaptersEditor() {
+  const { data: config, error, isLoading, mutate } = useCorrelationConfig()
+  const { isAdmin } = usePermissions()
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editing, setEditing] = useState<WebhookAdapter | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null)
+
+  const adapters = config?.webhook_adapters ?? []
+
+  const persist = useCallback(
+    async (updater: (adapters: WebhookAdapter[]) => WebhookAdapter[]) => {
+      if (!config) return
+      const next: CorrelationConfig = {
+        ...config,
+        webhook_adapters: updater(adapters),
+      }
+      try {
+        await updateCorrelationConfig(next)
+        await mutate()
+        toast.success("Webhook adapters saved")
+      } catch (e) {
+        toast.error("Failed to save", {
+          description: e instanceof Error ? e.message : String(e),
+        })
+      }
+    },
+    [config, adapters, mutate],
+  )
+
+  const handleUpsert = (adapter: WebhookAdapter) => {
+    persist((list) => {
+      const idx = list.findIndex((a) => a.name === adapter.name)
+      if (idx >= 0) {
+        const clone = [...list]
+        clone[idx] = adapter
+        return clone
+      }
+      return [...list, adapter]
+    })
+    setDialogOpen(false)
+    setEditing(null)
+  }
+
+  const handleDelete = () => {
+    if (!deleteTarget) return
+    const name = deleteTarget
+    persist((list) => list.filter((a) => a.name !== name))
+    setDeleteTarget(null)
+  }
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-mono flex items-center gap-2">
+            <Webhook className="h-4 w-4" /> Webhook Adapters
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-24 w-full" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-mono flex items-center gap-2">
+            <Webhook className="h-4 w-4" /> Webhook Adapters
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center gap-2 text-xs font-mono text-destructive">
+            <AlertCircle className="h-4 w-4" />
+            Failed to load configuration
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle className="text-sm font-mono flex items-center gap-2">
+          <Webhook className="h-4 w-4" /> Webhook Adapters
+          <Badge variant="secondary" className="ml-1 text-[10px]">
+            {adapters.length}
+          </Badge>
+        </CardTitle>
+        {isAdmin && (
+          <Button
+            size="sm"
+            variant="outline"
+            className="font-mono text-xs"
+            onClick={() => {
+              setEditing(newAdapter())
+              setDialogOpen(true)
+            }}
+          >
+            <Plus className="h-3 w-3 mr-1" /> Add Adapter
+          </Button>
+        )}
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <p className="text-xs font-mono text-muted-foreground">
+          Generic webhook endpoints at{" "}
+          <code className="px-1 py-0.5 bg-muted rounded">
+            POST /v1/signals/webhook/&#123;name&#125;
+          </code>
+          . Map arbitrary JSON payloads from any detector using JSONPath.
+        </p>
+
+        {adapters.length === 0 ? (
+          <div className="text-xs font-mono text-muted-foreground py-4 text-center border border-dashed rounded">
+            No webhook adapters configured
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {adapters.map((a) => (
+              <AdapterRow
+                key={a.name}
+                adapter={a}
+                canEdit={isAdmin}
+                onEdit={() => {
+                  setEditing(a)
+                  setDialogOpen(true)
+                }}
+                onDelete={() => setDeleteTarget(a.name)}
+              />
+            ))}
+          </div>
+        )}
+      </CardContent>
+
+      <AdapterDialog
+        open={dialogOpen}
+        onOpenChange={(o) => {
+          setDialogOpen(o)
+          if (!o) setEditing(null)
+        }}
+        initial={editing}
+        existingNames={adapters.map((a) => a.name)}
+        onSubmit={handleUpsert}
+      />
+
+      <AlertDialog
+        open={deleteTarget !== null}
+        onOpenChange={(o) => !o && setDeleteTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove webhook adapter?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will disable the <code>/v1/signals/webhook/{deleteTarget}</code>{" "}
+              endpoint. Existing events are unaffected. You can re-add it later.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete}>Remove</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  )
+}
+
+function AdapterRow({
+  adapter,
+  canEdit,
+  onEdit,
+  onDelete,
+}: {
+  adapter: WebhookAdapter
+  canEdit: boolean
+  onEdit: () => void
+  onDelete: () => void
+}) {
+  const endpoint = `/v1/signals/webhook/${adapter.name}`
+  return (
+    <div className="flex items-start justify-between rounded border p-3 gap-4">
+      <div className="flex-1 min-w-0 space-y-1.5">
+        <div className="flex items-center gap-2">
+          <code className="text-xs font-mono font-medium">{adapter.name}</code>
+          <Badge
+            variant={adapter.enabled ? "default" : "secondary"}
+            className="text-[10px] px-1 py-0"
+          >
+            {adapter.enabled ? "enabled" : "disabled"}
+          </Badge>
+          <Badge variant="outline" className="text-[10px] px-1 py-0">
+            auth: {adapter.auth.type}
+          </Badge>
+          {adapter.root_path && (
+            <Badge variant="outline" className="text-[10px] px-1 py-0">
+              batched
+            </Badge>
+          )}
+        </div>
+        {adapter.description && (
+          <div className="text-xs font-mono text-muted-foreground">
+            {adapter.description}
+          </div>
+        )}
+        <div className="flex items-center gap-2">
+          <code className="text-[11px] font-mono bg-muted px-1.5 py-0.5 rounded flex-1 truncate">
+            POST {endpoint}
+          </code>
+          <button
+            type="button"
+            aria-label="Copy endpoint"
+            onClick={() => {
+              navigator.clipboard.writeText(endpoint).then(() => {
+                toast.success("Endpoint copied")
+              })
+            }}
+            className="p-1 hover:bg-muted rounded"
+          >
+            <Copy className="h-3 w-3" />
+          </button>
+        </div>
+      </div>
+      {canEdit && (
+        <div className="flex items-center gap-1">
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 w-7 p-0"
+            aria-label="Edit adapter"
+            onClick={onEdit}
+          >
+            <Pencil className="h-3 w-3" />
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+            aria-label="Remove adapter"
+            onClick={onDelete}
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function AdapterDialog({
+  open,
+  onOpenChange,
+  initial,
+  existingNames,
+  onSubmit,
+}: {
+  open: boolean
+  onOpenChange: (o: boolean) => void
+  initial: WebhookAdapter | null
+  existingNames: string[]
+  onSubmit: (a: WebhookAdapter) => void
+}) {
+  const [form, setForm] = useState<WebhookAdapter>(initial ?? newAdapter())
+  const [saving, setSaving] = useState(false)
+
+  // Reset form when dialog opens with new adapter
+  useState(() => {
+    if (initial) setForm(initial)
+  })
+
+  const isNew = !existingNames.includes(form.name)
+  const errors = validateAdapter(form, existingNames, isNew)
+  const canSave = errors.length === 0
+
+  const handleSave = async () => {
+    if (!canSave) return
+    setSaving(true)
+    try {
+      await Promise.resolve(onSubmit(form))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        onOpenChange(o)
+        if (o && initial) setForm(initial)
+        if (o && !initial) setForm(newAdapter())
+      }}
+    >
+      <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="font-mono text-sm">
+            {initial && existingNames.includes(initial.name)
+              ? `Edit ${initial.name}`
+              : "New webhook adapter"}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 text-xs font-mono">
+          <Field
+            label="Name"
+            hint="URL path segment, [a-z0-9-]{1,64}"
+            value={form.name}
+            onChange={(v) => setForm({ ...form, name: v })}
+            disabled={initial !== null && existingNames.includes(initial.name)}
+            error={
+              !NAME_PATTERN.test(form.name) ? "Must match [a-z0-9-]{1,64}" : undefined
+            }
+          />
+
+          <Field
+            label="Description"
+            value={form.description}
+            onChange={(v) => setForm({ ...form, description: v })}
+          />
+
+          <div className="flex items-center gap-2">
+            <input
+              id="adapter-enabled"
+              type="checkbox"
+              checked={form.enabled}
+              onChange={(e) => setForm({ ...form, enabled: e.target.checked })}
+              className="h-3 w-3"
+            />
+            <Label htmlFor="adapter-enabled" className="text-xs font-mono">
+              Enabled
+            </Label>
+          </div>
+
+          <div className="border-t pt-3">
+            <div className="text-xs font-mono font-medium mb-2">Authentication</div>
+            <Select
+              value={form.auth.type}
+              onValueChange={(v) => setForm({ ...form, auth: defaultAuth(v as WebhookAuth["type"]) })}
+            >
+              <SelectTrigger className="h-8 text-xs font-mono">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="hmac" className="text-xs font-mono">
+                  HMAC-SHA256
+                </SelectItem>
+                <SelectItem value="bearer" className="text-xs font-mono">
+                  Bearer token
+                </SelectItem>
+                <SelectItem value="none" className="text-xs font-mono">
+                  None (insecure)
+                </SelectItem>
+              </SelectContent>
+            </Select>
+
+            {form.auth.type === "hmac" && (
+              <div className="space-y-2 mt-2 pl-2 border-l-2">
+                <Field
+                  label="Secret env var"
+                  hint="Name of the env var holding the HMAC secret (value never sent)"
+                  value={form.auth.secret_env}
+                  onChange={(v) =>
+                    setForm({
+                      ...form,
+                      auth: { ...(form.auth as Extract<WebhookAuth, { type: "hmac" }>), secret_env: v },
+                    })
+                  }
+                />
+                <Field
+                  label="Header"
+                  value={form.auth.header}
+                  onChange={(v) =>
+                    setForm({
+                      ...form,
+                      auth: { ...(form.auth as Extract<WebhookAuth, { type: "hmac" }>), header: v },
+                    })
+                  }
+                />
+              </div>
+            )}
+          </div>
+
+          <div className="border-t pt-3">
+            <div className="text-xs font-mono font-medium mb-2">Field Mappings (JSONPath)</div>
+            <FieldMapEditor
+              value={form.fields}
+              onChange={(fields) => setForm({ ...form, fields })}
+            />
+          </div>
+
+          <div className="border-t pt-3">
+            <div className="text-xs font-mono font-medium mb-2">Advanced</div>
+            <Field
+              label="root_path"
+              hint='Optional; iterate a JSON array (e.g. "$.alerts[*]")'
+              value={form.root_path ?? ""}
+              onChange={(v) => setForm({ ...form, root_path: v || null })}
+            />
+            <Field
+              label="default_vector"
+              hint="Fallback when vector field is missing or not in vector_map"
+              value={form.default_vector ?? ""}
+              onChange={(v) => setForm({ ...form, default_vector: v || null })}
+            />
+            <Field
+              label="confidence_scale"
+              hint="Divisor (e.g. 100 for 0-100 scales)"
+              value={form.confidence_scale?.toString() ?? ""}
+              onChange={(v) => {
+                const n = v === "" ? null : Number(v)
+                setForm({ ...form, confidence_scale: Number.isNaN(n) ? null : n })
+              }}
+            />
+            <Field
+              label="source_id_prefix"
+              hint='Prefix for extracted source_id (e.g. "radware-")'
+              value={form.source_id_prefix ?? ""}
+              onChange={(v) => setForm({ ...form, source_id_prefix: v || null })}
+            />
+
+            <div className="mt-3">
+              <Label className="text-xs font-mono">
+                vector_map <span className="text-muted-foreground">(one per line, raw=prefixd)</span>
+              </Label>
+              <Textarea
+                className="mt-1 text-xs font-mono h-20"
+                value={vectorMapToText(form.vector_map)}
+                onChange={(e) =>
+                  setForm({ ...form, vector_map: textToVectorMap(e.target.value) })
+                }
+                placeholder="UDP_FLOOD=udp_flood&#10;SYN_FLOOD=syn_flood"
+              />
+            </div>
+          </div>
+
+          {errors.length > 0 && (
+            <div className="rounded border border-destructive/30 bg-destructive/5 p-2 text-xs font-mono text-destructive space-y-0.5">
+              {errors.map((e) => (
+                <div key={e}>{e}</div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleSave}
+            disabled={!canSave || saving}
+            className="font-mono"
+          >
+            {saving ? (
+              <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+            ) : (
+              <Save className="h-3 w-3 mr-1" />
+            )}
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function Field({
+  label,
+  hint,
+  value,
+  onChange,
+  disabled,
+  error,
+}: {
+  label: string
+  hint?: string
+  value: string
+  onChange: (v: string) => void
+  disabled?: boolean
+  error?: string
+}) {
+  return (
+    <div className="space-y-1">
+      <Label className="text-xs font-mono">{label}</Label>
+      <Input
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        className="h-8 text-xs font-mono"
+      />
+      {error && <div className="text-[11px] text-destructive">{error}</div>}
+      {hint && !error && (
+        <div className="text-[11px] text-muted-foreground">{hint}</div>
+      )}
+    </div>
+  )
+}
+
+function FieldMapEditor({
+  value,
+  onChange,
+}: {
+  value: WebhookFieldMap
+  onChange: (v: WebhookFieldMap) => void
+}) {
+  const entries: Array<[keyof WebhookFieldMap, string, boolean]> = [
+    ["victim_ip", 'REQUIRED; e.g. "$.target.ip"', true],
+    ["vector", 'Optional; e.g. "$.alert_type"', false],
+    ["timestamp", 'Optional RFC3339 string', false],
+    ["bps", 'Optional number', false],
+    ["pps", 'Optional number', false],
+    ["confidence", 'Optional number', false],
+    ["source_id", 'Optional; used for dedup', false],
+    ["top_dst_ports", 'Optional array of ports', false],
+    ["action", 'Optional "ban" or "unban"', false],
+  ]
+  return (
+    <div className="space-y-2">
+      {entries.map(([key, hint, required]) => (
+        <Field
+          key={key}
+          label={key + (required ? " *" : "")}
+          hint={hint}
+          value={(value[key] ?? "") as string}
+          onChange={(v) => {
+            const next = { ...value }
+            if (required) {
+              ;(next as WebhookFieldMap).victim_ip = v
+            } else {
+              ;(next as Record<string, string | null>)[key as string] =
+                v || null
+            }
+            onChange(next)
+          }}
+        />
+      ))}
+    </div>
+  )
+}
+
+// Helpers
+
+function newAdapter(): WebhookAdapter {
+  return {
+    name: "",
+    description: "",
+    enabled: true,
+    auth: { type: "hmac", secret_env: "", header: "X-Signature-SHA256", algorithm: "sha256" },
+    root_path: null,
+    fields: {
+      victim_ip: "$.victim_ip",
+      vector: null,
+      timestamp: null,
+      bps: null,
+      pps: null,
+      confidence: null,
+      source_id: null,
+      top_dst_ports: null,
+      action: null,
+    },
+    vector_map: {},
+    default_vector: null,
+    confidence_scale: null,
+    source_id_prefix: null,
+  }
+}
+
+function defaultAuth(type: WebhookAuth["type"]): WebhookAuth {
+  switch (type) {
+    case "hmac":
+      return {
+        type: "hmac",
+        secret_env: "",
+        header: "X-Signature-SHA256",
+        algorithm: "sha256",
+      }
+    case "bearer":
+      return { type: "bearer" }
+    default:
+      return { type: "none" }
+  }
+}
+
+function vectorMapToText(map: Record<string, string> | undefined): string {
+  if (!map) return ""
+  return Object.entries(map)
+    .map(([k, v]) => `${k}=${v}`)
+    .join("\n")
+}
+
+function textToVectorMap(text: string): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith("#")) continue
+    const eq = trimmed.indexOf("=")
+    if (eq <= 0) continue
+    const k = trimmed.slice(0, eq).trim()
+    const v = trimmed.slice(eq + 1).trim()
+    if (k && v) out[k] = v
+  }
+  return out
+}
+
+export function validateAdapter(
+  adapter: WebhookAdapter,
+  existingNames: string[],
+  isNew: boolean,
+): string[] {
+  const errors: string[] = []
+  if (!NAME_PATTERN.test(adapter.name)) {
+    errors.push("name must match [a-z0-9-]{1,64}")
+  }
+  if (isNew && existingNames.includes(adapter.name)) {
+    errors.push(`name '${adapter.name}' is already in use`)
+  }
+  if (!adapter.fields.victim_ip) {
+    errors.push("fields.victim_ip is required")
+  }
+  if (adapter.auth.type === "hmac" && !adapter.auth.secret_env) {
+    errors.push("auth.secret_env is required for HMAC")
+  }
+  if (
+    adapter.confidence_scale !== null &&
+    adapter.confidence_scale !== undefined &&
+    adapter.confidence_scale <= 0
+  ) {
+    errors.push("confidence_scale must be > 0")
+  }
+  return errors
+}

--- a/frontend/components/dashboard/correlation/webhook-adapters.tsx
+++ b/frontend/components/dashboard/correlation/webhook-adapters.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useCallback } from "react"
+import { useState, useCallback, useEffect } from "react"
 import { toast } from "sonner"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -322,10 +322,10 @@ function AdapterDialog({
   const [form, setForm] = useState<WebhookAdapter>(initial ?? newAdapter())
   const [saving, setSaving] = useState(false)
 
-  // Reset form when dialog opens with new adapter
-  useState(() => {
-    if (initial) setForm(initial)
-  })
+  // Reset form whenever `initial` changes (dialog opened for a different adapter).
+  useEffect(() => {
+    setForm(initial ?? newAdapter())
+  }, [initial])
 
   const isNew = !existingNames.includes(form.name)
   const errors = validateAdapter(form, existingNames, isNew)

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -740,6 +740,36 @@ export interface SourceConfig {
   confidence_mapping: Record<string, number>
 }
 
+export interface WebhookFieldMap {
+  victim_ip: string
+  vector?: string | null
+  timestamp?: string | null
+  bps?: string | null
+  pps?: string | null
+  confidence?: string | null
+  source_id?: string | null
+  top_dst_ports?: string | null
+  action?: string | null
+}
+
+export type WebhookAuth =
+  | { type: "hmac"; secret_env: string; header: string; algorithm: string }
+  | { type: "bearer" }
+  | { type: "none" }
+
+export interface WebhookAdapter {
+  name: string
+  description: string
+  enabled: boolean
+  auth: WebhookAuth
+  root_path?: string | null
+  fields: WebhookFieldMap
+  vector_map?: Record<string, string>
+  default_vector?: string | null
+  confidence_scale?: number | null
+  source_id_prefix?: string | null
+}
+
 export interface CorrelationConfig {
   enabled: boolean
   window_seconds: number
@@ -747,6 +777,7 @@ export interface CorrelationConfig {
   confidence_threshold: number
   default_weight: number
   sources: Record<string, SourceConfig>
+  webhook_adapters?: WebhookAdapter[]
 }
 
 export interface CorrelationConfigResponse {

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -4778,3 +4778,240 @@ fn format_duration(seconds: i64) -> String {
         format!("{}m", minutes)
     }
 }
+
+// ==========================================================================
+// Generic webhook adapter
+// ==========================================================================
+
+/// Per-event result for the generic webhook endpoint.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct WebhookEventResult {
+    /// Position in the payload (0 for single-event adapters, 0..N for root_path).
+    pub index: usize,
+    /// Processing status (processed, duplicate, withdrawn, withdrawn_noop, error).
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event_id: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mitigation_id: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Response for the generic webhook endpoint.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct WebhookResponse {
+    pub processed: u32,
+    pub failed: u32,
+    pub results: Vec<WebhookEventResult>,
+}
+
+/// Ingest signals from a generic configured webhook adapter
+#[utoipa::path(
+    post,
+    path = "/v1/signals/webhook/{name}",
+    tag = "signals",
+    params(("name" = String, Path, description = "Adapter name as configured in correlation.yaml")),
+    request_body(content = serde_json::Value, description = "Arbitrary JSON payload mapped via the adapter's JSONPath fields"),
+    responses(
+        (status = 200, description = "Events processed", body = WebhookResponse),
+        (status = 400, description = "Malformed payload or no mappable events"),
+        (status = 401, description = "HMAC/bearer verification failed"),
+        (status = 404, description = "Adapter not configured or disabled"),
+    )
+)]
+pub async fn ingest_webhook(
+    State(state): State<Arc<AppState>>,
+    auth_session: AuthSession,
+    Path(name): Path<String>,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> impl IntoResponse {
+    ingest_webhook_inner(state, auth_session, name, headers, body).await
+}
+
+async fn ingest_webhook_inner(
+    state: Arc<AppState>,
+    auth_session: AuthSession,
+    name: String,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> Result<(StatusCode, Json<WebhookResponse>), AppError> {
+    if !crate::correlation::is_valid_name(&name) {
+        return Err(AppError(PrefixdError::NotFound(format!(
+            "webhook adapter '{name}' not found"
+        ))));
+    }
+
+    // Resolve adapter config
+    let (adapter, compiled) = {
+        let cfg = state.correlation_config.read().await;
+        let adapter = cfg
+            .webhook_adapters
+            .iter()
+            .find(|a| a.name == name && a.enabled)
+            .cloned()
+            .ok_or_else(|| {
+                AppError(PrefixdError::NotFound(format!(
+                    "webhook adapter '{name}' not found"
+                )))
+            })?;
+        drop(cfg);
+        let compiled = crate::correlation::CompiledAdapter::compile(&adapter).map_err(|e| {
+            AppError(PrefixdError::Internal(format!(
+                "adapter '{name}' has invalid JSONPath: {e}"
+            )))
+        })?;
+        (adapter, compiled)
+    };
+
+    // Auth check per adapter
+    match &adapter.auth {
+        crate::correlation::WebhookAuth::Hmac {
+            secret_env,
+            header,
+            algorithm,
+        } => {
+            if algorithm != "sha256" {
+                return Err(AppError(PrefixdError::Internal(format!(
+                    "adapter '{name}' uses unsupported HMAC algorithm '{algorithm}'"
+                ))));
+            }
+            let Ok(secret) = std::env::var(secret_env) else {
+                return Err(AppError(PrefixdError::Internal(format!(
+                    "adapter '{name}' HMAC secret env var '{secret_env}' not set"
+                ))));
+            };
+            let sig = headers
+                .get(header.as_str())
+                .and_then(|v| v.to_str().ok())
+                .ok_or_else(|| {
+                    AppError(PrefixdError::Unauthorized(format!(
+                        "missing HMAC signature header '{header}'"
+                    )))
+                })?;
+            if !crate::correlation::verify_hmac_sha256(secret.as_bytes(), &body, sig) {
+                return Err(AppError(PrefixdError::Unauthorized(
+                    "HMAC signature verification failed".into(),
+                )));
+            }
+        }
+        crate::correlation::WebhookAuth::Bearer => {
+            let auth_header = headers.get(AUTHORIZATION).and_then(|h| h.to_str().ok());
+            if require_auth(&state, &auth_session, auth_header).is_err() {
+                return Err(AppError(PrefixdError::Unauthorized(
+                    "authentication required".into(),
+                )));
+            }
+        }
+        crate::correlation::WebhookAuth::None => {
+            // No-auth is caller's responsibility; logged once at startup.
+        }
+    }
+
+    // Parse body
+    let payload: serde_json::Value = serde_json::from_slice(&body).map_err(|e| {
+        AppError(PrefixdError::InvalidRequest(format!(
+            "malformed JSON payload: {e}"
+        )))
+    })?;
+
+    let mapped = crate::correlation::map_payload(&adapter, &compiled, &payload);
+    if mapped.is_empty() {
+        return Err(AppError(PrefixdError::InvalidRequest(
+            "no events extracted from payload".into(),
+        )));
+    }
+
+    let mut results = Vec::with_capacity(mapped.len());
+    let mut processed = 0u32;
+    let mut failed = 0u32;
+
+    for (index, mapped_event) in mapped.into_iter().enumerate() {
+        match mapped_event {
+            Err(e) => {
+                failed += 1;
+                results.push(WebhookEventResult {
+                    index,
+                    status: "error".into(),
+                    event_id: None,
+                    mitigation_id: None,
+                    error: Some(e.to_string()),
+                });
+            }
+            Ok(input) => match input.action.as_str() {
+                "unban" => match handle_unban(state.clone(), input).await {
+                    Ok((_status, Json(resp))) => {
+                        processed += 1;
+                        results.push(WebhookEventResult {
+                            index,
+                            status: "withdrawn".into(),
+                            event_id: Some(resp.event_id),
+                            mitigation_id: resp.mitigation_id,
+                            error: None,
+                        });
+                    }
+                    Err(AppError(e)) => {
+                        processed += 1;
+                        results.push(WebhookEventResult {
+                            index,
+                            status: "withdrawn_noop".into(),
+                            event_id: None,
+                            mitigation_id: None,
+                            error: Some(e.to_string()),
+                        });
+                    }
+                },
+                _ => match handle_ban(state.clone(), input).await {
+                    Ok((_status, Json(resp))) => {
+                        processed += 1;
+                        results.push(WebhookEventResult {
+                            index,
+                            status: resp.status,
+                            event_id: Some(resp.event_id),
+                            mitigation_id: resp.mitigation_id,
+                            error: None,
+                        });
+                    }
+                    Err(AppError(PrefixdError::DuplicateEvent { .. })) => {
+                        processed += 1;
+                        results.push(WebhookEventResult {
+                            index,
+                            status: "duplicate".into(),
+                            event_id: None,
+                            mitigation_id: None,
+                            error: None,
+                        });
+                    }
+                    Err(AppError(e)) => {
+                        failed += 1;
+                        results.push(WebhookEventResult {
+                            index,
+                            status: "error".into(),
+                            event_id: None,
+                            mitigation_id: None,
+                            error: Some(e.to_string()),
+                        });
+                    }
+                },
+            },
+        }
+    }
+
+    tracing::info!(
+        adapter = %adapter.name,
+        processed = processed,
+        failed = failed,
+        total = results.len(),
+        "webhook payload processed"
+    );
+
+    Ok((
+        StatusCode::OK,
+        Json(WebhookResponse {
+            processed,
+            failed,
+            results,
+        }),
+    ))
+}

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -8,12 +8,13 @@ use super::handlers::{
     ErrorResponse, EventResponse, EventsListResponse, FastNetMonAttackDetails, FastNetMonPayload,
     HealthResponse, IpHistoryResponse, MitigationResponse, MitigationsListResponse,
     PublicHealthResponse, ReloadResponse, SignalGroupDetailResponse, SignalGroupsListResponse,
-    TimeseriesResponse,
+    TimeseriesResponse, WebhookEventResult, WebhookResponse,
 };
 use crate::correlation::config::{CorrelationConfig, SourceConfig};
 use crate::correlation::engine::{
     CorrelationExplanation, SignalGroup, SignalGroupEvent, SignalGroupStatus, SourceContribution,
 };
+use crate::correlation::webhook::{WebhookAdapter, WebhookAuth, WebhookFieldMap};
 use crate::db::{GlobalStats, NotificationPreferences, PopInfo, PopStats, SafelistEntry};
 
 #[derive(OpenApi)]
@@ -57,6 +58,7 @@ use crate::db::{GlobalStats, NotificationPreferences, PopInfo, PopStats, Safelis
         super::handlers::get_signal_group,
         super::handlers::ingest_alertmanager,
         super::handlers::ingest_fastnetmon,
+        super::handlers::ingest_webhook,
         super::handlers::get_correlation_config,
         super::handlers::update_correlation_config,
     ),
@@ -104,6 +106,11 @@ use crate::db::{GlobalStats, NotificationPreferences, PopInfo, PopStats, Safelis
             SourceContribution,
             CorrelationConfig,
             SourceConfig,
+            WebhookAdapter,
+            WebhookAuth,
+            WebhookFieldMap,
+            WebhookResponse,
+            WebhookEventResult,
         )
     ),
     tags(

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -117,6 +117,7 @@ fn api_routes() -> Router<Arc<AppState>> {
             post(handlers::ingest_alertmanager),
         )
         .route("/v1/signals/fastnetmon", post(handlers::ingest_fastnetmon))
+        .route("/v1/signals/webhook/{name}", post(handlers::ingest_webhook))
 }
 
 /// Common layers applied to both production and test routers

--- a/src/correlation/config.rs
+++ b/src/correlation/config.rs
@@ -38,6 +38,11 @@ pub struct CorrelationConfig {
     /// Default weight assigned to events from sources not listed in `sources`.
     #[serde(default = "default_weight")]
     pub default_weight: f32,
+
+    /// Generic webhook adapters, each exposed at `POST /v1/signals/webhook/{name}`.
+    /// See `docs/configuration.md` for the schema.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub webhook_adapters: Vec<super::webhook::WebhookAdapter>,
 }
 
 /// Configuration for a single detection/signal source.
@@ -82,6 +87,7 @@ impl Default for CorrelationConfig {
             confidence_threshold: default_confidence_threshold(),
             sources: HashMap::new(),
             default_weight: default_weight(),
+            webhook_adapters: Vec::new(),
         }
     }
 }
@@ -244,6 +250,28 @@ impl CorrelationConfig {
             }
         }
 
+        let mut seen_names = std::collections::HashSet::new();
+        for adapter in &self.webhook_adapters {
+            if !super::webhook::is_valid_name(&adapter.name) {
+                errors.push(format!(
+                    "webhook_adapter '{}': name must match [a-z0-9-]{{1,64}}",
+                    adapter.name
+                ));
+            }
+            if !seen_names.insert(adapter.name.clone()) {
+                errors.push(format!(
+                    "webhook_adapter '{}': duplicate name",
+                    adapter.name
+                ));
+            }
+            if let Err(e) = super::webhook::CompiledAdapter::compile(adapter) {
+                errors.push(format!(
+                    "webhook_adapter '{}': invalid JSONPath: {}",
+                    adapter.name, e
+                ));
+            }
+        }
+
         errors
     }
 
@@ -265,6 +293,39 @@ impl CorrelationConfig {
             })
             .collect();
 
+        let webhook_adapters: Vec<serde_json::Value> = self
+            .webhook_adapters
+            .iter()
+            .map(|a| {
+                let auth_json = match &a.auth {
+                    super::webhook::WebhookAuth::Hmac {
+                        secret_env,
+                        header,
+                        algorithm,
+                    } => serde_json::json!({
+                        "type": "hmac",
+                        "secret_env": secret_env,
+                        "header": header,
+                        "algorithm": algorithm,
+                    }),
+                    super::webhook::WebhookAuth::Bearer => serde_json::json!({ "type": "bearer" }),
+                    super::webhook::WebhookAuth::None => serde_json::json!({ "type": "none" }),
+                };
+                serde_json::json!({
+                    "name": a.name,
+                    "description": a.description,
+                    "enabled": a.enabled,
+                    "auth": auth_json,
+                    "root_path": a.root_path,
+                    "fields": a.fields,
+                    "vector_map": a.vector_map,
+                    "default_vector": a.default_vector,
+                    "confidence_scale": a.confidence_scale,
+                    "source_id_prefix": a.source_id_prefix,
+                })
+            })
+            .collect();
+
         serde_json::json!({
             "enabled": self.enabled,
             "window_seconds": self.window_seconds,
@@ -272,6 +333,7 @@ impl CorrelationConfig {
             "confidence_threshold": self.confidence_threshold,
             "default_weight": self.default_weight,
             "sources": sources,
+            "webhook_adapters": webhook_adapters,
         })
     }
 }

--- a/src/correlation/config.rs
+++ b/src/correlation/config.rs
@@ -270,6 +270,41 @@ impl CorrelationConfig {
                     adapter.name, e
                 ));
             }
+
+            if let Some(scale) = adapter.confidence_scale {
+                if !scale.is_finite() || scale <= 0.0_f32 {
+                    errors.push(format!(
+                        "webhook_adapter '{}': confidence_scale must be a finite value > 0 (got {})",
+                        adapter.name, scale
+                    ));
+                }
+            }
+
+            if let super::webhook::WebhookAuth::Hmac {
+                secret_env,
+                header,
+                algorithm,
+            } = &adapter.auth
+            {
+                if secret_env.trim().is_empty() {
+                    errors.push(format!(
+                        "webhook_adapter '{}': auth.secret_env must not be empty for HMAC",
+                        adapter.name
+                    ));
+                }
+                if header.trim().is_empty() {
+                    errors.push(format!(
+                        "webhook_adapter '{}': auth.header must not be empty for HMAC",
+                        adapter.name
+                    ));
+                }
+                if algorithm != "sha256" {
+                    errors.push(format!(
+                        "webhook_adapter '{}': auth.algorithm must be \"sha256\" (got \"{}\")",
+                        adapter.name, algorithm
+                    ));
+                }
+            }
         }
 
         errors
@@ -782,5 +817,121 @@ sources:
         assert!(loaded.enabled);
         assert_eq!(loaded.min_sources, 3);
         assert_eq!(loaded.sources["test"].weight, 1.5);
+    }
+
+    fn webhook_adapter_for_tests() -> super::super::webhook::WebhookAdapter {
+        super::super::webhook::WebhookAdapter {
+            name: "radware".into(),
+            description: String::new(),
+            enabled: true,
+            auth: super::super::webhook::WebhookAuth::Hmac {
+                secret_env: "RADWARE_SECRET".into(),
+                header: "X-Signature-SHA256".into(),
+                algorithm: "sha256".into(),
+            },
+            root_path: None,
+            fields: super::super::webhook::WebhookFieldMap {
+                victim_ip: "$.target.ip".into(),
+                vector: None,
+                timestamp: None,
+                bps: None,
+                pps: None,
+                confidence: None,
+                source_id: None,
+                top_dst_ports: None,
+                action: None,
+            },
+            vector_map: HashMap::new(),
+            default_vector: None,
+            confidence_scale: None,
+            source_id_prefix: None,
+        }
+    }
+
+    #[test]
+    fn validate_rejects_nonpositive_confidence_scale() {
+        let mut config = CorrelationConfig::default();
+        let mut adapter = webhook_adapter_for_tests();
+        adapter.confidence_scale = Some(0.0);
+        config.webhook_adapters.push(adapter);
+        let errors = config.validate();
+        assert!(
+            errors.iter().any(|e| e.contains("confidence_scale")),
+            "expected confidence_scale error, got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_non_finite_confidence_scale() {
+        let mut config = CorrelationConfig::default();
+        let mut adapter = webhook_adapter_for_tests();
+        adapter.confidence_scale = Some(f32::INFINITY);
+        config.webhook_adapters.push(adapter);
+        let errors = config.validate();
+        assert!(
+            errors.iter().any(|e| e.contains("confidence_scale")),
+            "expected confidence_scale error, got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_empty_hmac_secret_env() {
+        let mut config = CorrelationConfig::default();
+        let mut adapter = webhook_adapter_for_tests();
+        adapter.auth = super::super::webhook::WebhookAuth::Hmac {
+            secret_env: "   ".into(),
+            header: "X-Signature-SHA256".into(),
+            algorithm: "sha256".into(),
+        };
+        config.webhook_adapters.push(adapter);
+        let errors = config.validate();
+        assert!(
+            errors.iter().any(|e| e.contains("secret_env")),
+            "expected secret_env error, got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_empty_hmac_header() {
+        let mut config = CorrelationConfig::default();
+        let mut adapter = webhook_adapter_for_tests();
+        adapter.auth = super::super::webhook::WebhookAuth::Hmac {
+            secret_env: "SECRET".into(),
+            header: String::new(),
+            algorithm: "sha256".into(),
+        };
+        config.webhook_adapters.push(adapter);
+        let errors = config.validate();
+        assert!(
+            errors.iter().any(|e| e.contains("auth.header")),
+            "expected auth.header error, got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_unknown_hmac_algorithm() {
+        let mut config = CorrelationConfig::default();
+        let mut adapter = webhook_adapter_for_tests();
+        adapter.auth = super::super::webhook::WebhookAuth::Hmac {
+            secret_env: "SECRET".into(),
+            header: "X-Signature-SHA256".into(),
+            algorithm: "sha512".into(),
+        };
+        config.webhook_adapters.push(adapter);
+        let errors = config.validate();
+        assert!(
+            errors.iter().any(|e| e.contains("auth.algorithm")),
+            "expected auth.algorithm error, got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_valid_webhook_adapter() {
+        let mut config = CorrelationConfig::default();
+        let mut adapter = webhook_adapter_for_tests();
+        adapter.confidence_scale = Some(100.0);
+        config.webhook_adapters.push(adapter);
+        let errors = config.validate();
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
     }
 }

--- a/src/correlation/mod.rs
+++ b/src/correlation/mod.rs
@@ -1,5 +1,10 @@
 pub mod config;
 pub mod engine;
+pub mod webhook;
 
 pub use config::*;
 pub use engine::*;
+pub use webhook::{
+    CompiledAdapter, MapError, WebhookAdapter, WebhookAuth, WebhookFieldMap, is_valid_name,
+    map_payload, verify_hmac_sha256,
+};

--- a/src/correlation/webhook.rs
+++ b/src/correlation/webhook.rs
@@ -149,6 +149,11 @@ pub enum MapError {
     InvalidIp(String),
     #[error("invalid timestamp '{0}' in payload")]
     InvalidTimestamp(String),
+    #[error("invalid value for field '{field}' (expected {expected})")]
+    InvalidValue {
+        field: &'static str,
+        expected: &'static str,
+    },
 }
 
 /// Validate that a webhook adapter name is safe for use as a URL path segment.
@@ -326,14 +331,20 @@ fn map_one(
                 .collect::<Vec<u16>>()
         });
 
-    let action = compiled
+    let action = match compiled
         .action
         .as_ref()
         .and_then(|p| p.query(node).at_most_one().ok().flatten())
-        .and_then(|v| v.as_str())
-        .filter(|s| *s == "ban" || *s == "unban")
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| "ban".to_string());
+    {
+        None | Some(Value::Null) => "ban".to_string(),
+        Some(Value::String(s)) if s == "ban" || s == "unban" => s.clone(),
+        Some(_) => {
+            return Err(MapError::InvalidValue {
+                field: "action",
+                expected: "\"ban\" or \"unban\"",
+            });
+        }
+    };
 
     Ok(AttackEventInput {
         event_id,
@@ -488,6 +499,43 @@ mod tests {
             results.into_iter().next().unwrap(),
             Err(MapError::MissingRequired("victim_ip"))
         ));
+    }
+
+    #[test]
+    fn invalid_action_value_is_rejected() {
+        let mut adapter = basic_adapter();
+        adapter.fields.action = Some("$.action".into());
+        let compiled = CompiledAdapter::compile(&adapter).unwrap();
+        let body = json!({
+            "target": { "ip": "203.0.113.5" },
+            "alert_type": "udp_flood",
+            "action": "resolved"
+        });
+        let results = map_payload(&adapter, &compiled, &body);
+        assert!(matches!(
+            results.into_iter().next().unwrap(),
+            Err(MapError::InvalidValue {
+                field: "action",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn missing_action_defaults_to_ban() {
+        let mut adapter = basic_adapter();
+        adapter.fields.action = Some("$.action".into());
+        let compiled = CompiledAdapter::compile(&adapter).unwrap();
+        let body = json!({
+            "target": { "ip": "203.0.113.5" },
+            "alert_type": "udp_flood"
+        });
+        let event = map_payload(&adapter, &compiled, &body)
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
+        assert_eq!(event.action, "ban");
     }
 
     #[test]

--- a/src/correlation/webhook.rs
+++ b/src/correlation/webhook.rs
@@ -1,0 +1,641 @@
+//! Generic webhook adapter.
+//!
+//! Accepts arbitrary JSON payloads from any detector or telemetry source and
+//! maps them to [`AttackEventInput`] via operator-defined JSONPath expressions.
+//!
+//! Adapters are configured per-name in `correlation.yaml` and reachable at
+//! `POST /v1/signals/webhook/{name}`. Each adapter specifies:
+//!
+//! - `fields`: JSONPath -> event field mapping
+//! - `auth`: HMAC, bearer, or none
+//! - `root_path`: optional iterator for batched payloads
+//! - `vector_map`: optional detector-vector string normalization
+//! - `confidence_scale`: optional divisor for extracted confidence
+//!
+//! See `docs/configuration.md` for the full schema and examples.
+
+use chrono::{DateTime, Utc};
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use serde_json_path::JsonPath;
+use sha2::Sha256;
+use std::collections::HashMap;
+use subtle::ConstantTimeEq;
+
+use crate::domain::{AttackEventInput, AttackVector};
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Webhook adapter spec loaded from correlation.yaml.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct WebhookAdapter {
+    /// URL-path segment: lowercase alphanumerics and hyphens.
+    pub name: String,
+
+    /// Human-readable description.
+    #[serde(default)]
+    pub description: String,
+
+    /// Whether the adapter is active. Disabled adapters return 404.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// Authentication scheme for this adapter.
+    pub auth: WebhookAuth,
+
+    /// Optional JSONPath to extract an array of alert nodes from the payload.
+    /// If absent, the whole payload is treated as a single event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root_path: Option<String>,
+
+    /// JSONPath mapping for event fields. `victim_ip` is required.
+    pub fields: WebhookFieldMap,
+
+    /// Optional normalization map for the `vector` string extracted from payload.
+    /// Keys are the raw detector strings, values are prefixd vector names
+    /// (udp_flood, syn_flood, ack_flood, icmp_flood, unknown).
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub vector_map: HashMap<String, String>,
+
+    /// Fallback vector when `fields.vector` is missing or not in `vector_map`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_vector: Option<String>,
+
+    /// If set, the extracted confidence value is divided by this. Useful when
+    /// a detector reports confidence on a 0-100 scale (set `confidence_scale: 100`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confidence_scale: Option<f32>,
+
+    /// Optional prefix prepended to extracted `source_id` values (for dedup).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_id_prefix: Option<String>,
+}
+
+/// JSONPath expressions for each mapped event field.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct WebhookFieldMap {
+    /// Required: JSONPath that extracts the victim IP string.
+    pub victim_ip: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vector: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bps: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pps: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub top_dst_ports: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub action: Option<String>,
+}
+
+/// Authentication scheme for a webhook adapter.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum WebhookAuth {
+    /// HMAC-SHA256 signature verification. Secret loaded from `secret_env`.
+    Hmac {
+        /// Env var name holding the HMAC secret (never serialized in config views).
+        secret_env: String,
+        /// Request header carrying the hex-encoded HMAC digest.
+        #[serde(default = "default_hmac_header")]
+        header: String,
+        /// Hash algorithm. Only `sha256` supported in v1.
+        #[serde(default = "default_hmac_algorithm")]
+        algorithm: String,
+    },
+    /// Authenticated session (reuses the global auth backend).
+    Bearer,
+    /// No authentication. Insecure; use only in trusted networks.
+    None,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_hmac_header() -> String {
+    "X-Signature-SHA256".to_string()
+}
+
+fn default_hmac_algorithm() -> String {
+    "sha256".to_string()
+}
+
+/// Error produced when mapping a single payload node to an `AttackEventInput`.
+#[derive(Debug, thiserror::Error)]
+pub enum MapError {
+    #[error("invalid JSONPath expression '{path}' for field '{field}': {source}")]
+    InvalidPath {
+        field: String,
+        path: String,
+        source: serde_json_path::ParseError,
+    },
+    #[error("required field '{0}' missing from payload")]
+    MissingRequired(&'static str),
+    #[error("field '{field}' has wrong type in payload (expected {expected})")]
+    WrongType {
+        field: &'static str,
+        expected: &'static str,
+    },
+    #[error("invalid IP address '{0}' in payload")]
+    InvalidIp(String),
+    #[error("invalid timestamp '{0}' in payload")]
+    InvalidTimestamp(String),
+}
+
+/// Validate that a webhook adapter name is safe for use as a URL path segment.
+///
+/// Allowed: `[a-z0-9-]{1,64}` (lowercase alphanumerics + hyphens).
+pub fn is_valid_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 64
+        && name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
+
+/// Compiled JSONPath expressions for a single adapter.
+///
+/// Caching these lets the hot path (event ingestion) skip re-parsing on every
+/// request. Build once at adapter registration or per-request if the config
+/// changes often.
+pub struct CompiledAdapter {
+    pub root: Option<JsonPath>,
+    pub victim_ip: JsonPath,
+    pub vector: Option<JsonPath>,
+    pub timestamp: Option<JsonPath>,
+    pub bps: Option<JsonPath>,
+    pub pps: Option<JsonPath>,
+    pub confidence: Option<JsonPath>,
+    pub source_id: Option<JsonPath>,
+    pub top_dst_ports: Option<JsonPath>,
+    pub action: Option<JsonPath>,
+}
+
+impl CompiledAdapter {
+    pub fn compile(adapter: &WebhookAdapter) -> Result<Self, MapError> {
+        let compile_opt =
+            |field: &'static str, path: &Option<String>| -> Result<Option<JsonPath>, MapError> {
+                match path.as_ref() {
+                    Some(p) => match JsonPath::parse(p) {
+                        Ok(j) => Ok(Some(j)),
+                        Err(source) => Err(MapError::InvalidPath {
+                            field: field.to_string(),
+                            path: p.clone(),
+                            source,
+                        }),
+                    },
+                    None => Ok(None),
+                }
+            };
+
+        Ok(Self {
+            root: compile_opt("root_path", &adapter.root_path)?,
+            victim_ip: JsonPath::parse(&adapter.fields.victim_ip).map_err(|source| {
+                MapError::InvalidPath {
+                    field: "victim_ip".to_string(),
+                    path: adapter.fields.victim_ip.clone(),
+                    source,
+                }
+            })?,
+            vector: compile_opt("vector", &adapter.fields.vector)?,
+            timestamp: compile_opt("timestamp", &adapter.fields.timestamp)?,
+            bps: compile_opt("bps", &adapter.fields.bps)?,
+            pps: compile_opt("pps", &adapter.fields.pps)?,
+            confidence: compile_opt("confidence", &adapter.fields.confidence)?,
+            source_id: compile_opt("source_id", &adapter.fields.source_id)?,
+            top_dst_ports: compile_opt("top_dst_ports", &adapter.fields.top_dst_ports)?,
+            action: compile_opt("action", &adapter.fields.action)?,
+        })
+    }
+}
+
+/// Extract zero or more `AttackEventInput`s from a payload using adapter rules.
+///
+/// If the adapter has a `root_path`, each matching JSON node produces one event.
+/// Otherwise the whole body is mapped once.
+pub fn map_payload(
+    adapter: &WebhookAdapter,
+    compiled: &CompiledAdapter,
+    body: &Value,
+) -> Vec<Result<AttackEventInput, MapError>> {
+    let nodes: Vec<&Value> = match &compiled.root {
+        Some(root) => root.query(body).all().into_iter().collect(),
+        None => vec![body],
+    };
+
+    nodes
+        .into_iter()
+        .map(|n| map_one(adapter, compiled, n))
+        .collect()
+}
+
+fn map_one(
+    adapter: &WebhookAdapter,
+    compiled: &CompiledAdapter,
+    node: &Value,
+) -> Result<AttackEventInput, MapError> {
+    let victim_ip_val = compiled
+        .victim_ip
+        .query(node)
+        .at_most_one()
+        .ok()
+        .flatten()
+        .ok_or(MapError::MissingRequired("victim_ip"))?;
+    let victim_ip = victim_ip_val
+        .as_str()
+        .ok_or(MapError::WrongType {
+            field: "victim_ip",
+            expected: "string",
+        })?
+        .to_string();
+    if victim_ip.parse::<std::net::IpAddr>().is_err() {
+        return Err(MapError::InvalidIp(victim_ip));
+    }
+
+    let timestamp = match compiled.timestamp.as_ref() {
+        Some(p) => match p.query(node).at_most_one().ok().flatten() {
+            Some(v) => {
+                let s = v.as_str().ok_or(MapError::WrongType {
+                    field: "timestamp",
+                    expected: "string",
+                })?;
+                s.parse::<DateTime<Utc>>()
+                    .map_err(|_| MapError::InvalidTimestamp(s.to_string()))?
+            }
+            None => Utc::now(),
+        },
+        None => Utc::now(),
+    };
+
+    let vector = {
+        let raw = compiled
+            .vector
+            .as_ref()
+            .and_then(|p| p.query(node).at_most_one().ok().flatten())
+            .and_then(|v| v.as_str().map(|s| s.to_string()));
+        resolve_vector(adapter, raw.as_deref())
+    };
+
+    let bps = extract_i64(&compiled.bps, node)?;
+    let pps = extract_i64(&compiled.pps, node)?;
+
+    let confidence_raw = compiled
+        .confidence
+        .as_ref()
+        .and_then(|p| p.query(node).at_most_one().ok().flatten())
+        .and_then(|v| v.as_f64())
+        .map(|x| x as f32);
+    let confidence = confidence_raw.map(|c| {
+        let scaled = adapter.confidence_scale.map(|s| c / s).unwrap_or(c);
+        scaled.clamp(0.0, 1.0)
+    });
+
+    let event_id = compiled
+        .source_id
+        .as_ref()
+        .and_then(|p| p.query(node).at_most_one().ok().flatten())
+        .and_then(|v| match v {
+            Value::String(s) => Some(s.clone()),
+            Value::Number(n) => Some(n.to_string()),
+            _ => None,
+        })
+        .map(|s| match &adapter.source_id_prefix {
+            Some(pfx) => format!("{pfx}{s}"),
+            None => s,
+        });
+
+    let top_dst_ports = compiled
+        .top_dst_ports
+        .as_ref()
+        .and_then(|p| p.query(node).at_most_one().ok().flatten())
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|x| x.as_u64())
+                .filter(|&x| x <= u16::MAX as u64)
+                .map(|x| x as u16)
+                .collect::<Vec<u16>>()
+        });
+
+    let action = compiled
+        .action
+        .as_ref()
+        .and_then(|p| p.query(node).at_most_one().ok().flatten())
+        .and_then(|v| v.as_str())
+        .filter(|s| *s == "ban" || *s == "unban")
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "ban".to_string());
+
+    Ok(AttackEventInput {
+        event_id,
+        timestamp,
+        source: adapter.name.clone(),
+        victim_ip,
+        vector,
+        bps,
+        pps,
+        top_dst_ports,
+        confidence,
+        action,
+        raw_details: Some(node.clone()),
+    })
+}
+
+fn extract_i64(path: &Option<JsonPath>, node: &Value) -> Result<Option<i64>, MapError> {
+    let Some(p) = path.as_ref() else {
+        return Ok(None);
+    };
+    let Some(v) = p.query(node).at_most_one().ok().flatten() else {
+        return Ok(None);
+    };
+    match v {
+        Value::Number(n) => Ok(n.as_i64().or_else(|| n.as_f64().map(|f| f as i64))),
+        Value::Null => Ok(None),
+        _ => Ok(None),
+    }
+}
+
+fn resolve_vector(adapter: &WebhookAdapter, raw: Option<&str>) -> AttackVector {
+    let normalized: Option<String> = raw.and_then(|r| {
+        adapter
+            .vector_map
+            .get(r)
+            .cloned()
+            .or_else(|| Some(r.to_string()))
+    });
+    match normalized {
+        Some(s) => s
+            .parse::<AttackVector>()
+            .unwrap_or_else(|_| fallback_vector(adapter)),
+        None => fallback_vector(adapter),
+    }
+}
+
+fn fallback_vector(adapter: &WebhookAdapter) -> AttackVector {
+    adapter
+        .default_vector
+        .as_ref()
+        .and_then(|s| s.parse::<AttackVector>().ok())
+        .unwrap_or(AttackVector::Unknown)
+}
+
+/// Verify an HMAC-SHA256 signature header against a request body.
+///
+/// The header value is expected to be a hex-encoded digest, optionally
+/// prefixed with `sha256=` (GitHub-style). Comparison is constant-time.
+pub fn verify_hmac_sha256(secret: &[u8], body: &[u8], header_value: &str) -> bool {
+    let expected_hex = header_value.strip_prefix("sha256=").unwrap_or(header_value);
+    let Ok(expected) = hex::decode(expected_hex.trim()) else {
+        return false;
+    };
+
+    let Ok(mut mac) = HmacSha256::new_from_slice(secret) else {
+        return false;
+    };
+    mac.update(body);
+    let computed = mac.finalize().into_bytes();
+
+    computed.ct_eq(&expected).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn basic_adapter() -> WebhookAdapter {
+        WebhookAdapter {
+            name: "test".into(),
+            description: String::new(),
+            enabled: true,
+            auth: WebhookAuth::None,
+            root_path: None,
+            fields: WebhookFieldMap {
+                victim_ip: "$.target.ip".into(),
+                vector: Some("$.alert_type".into()),
+                timestamp: Some("$.time".into()),
+                bps: Some("$.metrics.bps".into()),
+                pps: Some("$.metrics.pps".into()),
+                confidence: Some("$.score".into()),
+                source_id: Some("$.id".into()),
+                top_dst_ports: Some("$.ports".into()),
+                action: Some("$.action".into()),
+            },
+            vector_map: HashMap::new(),
+            default_vector: None,
+            confidence_scale: None,
+            source_id_prefix: None,
+        }
+    }
+
+    #[test]
+    fn valid_name_rules() {
+        assert!(is_valid_name("radware"));
+        assert!(is_valid_name("fastnetmon-v2"));
+        assert!(is_valid_name("detector-99"));
+        assert!(!is_valid_name(""));
+        assert!(!is_valid_name("Upper"));
+        assert!(!is_valid_name("has space"));
+        assert!(!is_valid_name("has/slash"));
+        assert!(!is_valid_name(&"a".repeat(65)));
+    }
+
+    #[test]
+    fn maps_all_fields_happy_path() {
+        let adapter = basic_adapter();
+        let compiled = CompiledAdapter::compile(&adapter).unwrap();
+        let body = json!({
+            "id": "alert-42",
+            "target": { "ip": "203.0.113.5" },
+            "alert_type": "udp_flood",
+            "time": "2026-01-01T00:00:00Z",
+            "metrics": { "bps": 100000, "pps": 200 },
+            "score": 0.85,
+            "ports": [53, 123],
+            "action": "ban",
+        });
+
+        let results = map_payload(&adapter, &compiled, &body);
+        assert_eq!(results.len(), 1);
+        let event = results.into_iter().next().unwrap().unwrap();
+        assert_eq!(event.event_id.as_deref(), Some("alert-42"));
+        assert_eq!(event.victim_ip, "203.0.113.5");
+        assert_eq!(event.vector, AttackVector::UdpFlood);
+        assert_eq!(event.bps, Some(100000));
+        assert_eq!(event.pps, Some(200));
+        assert_eq!(event.confidence, Some(0.85));
+        assert_eq!(event.top_dst_ports, Some(vec![53, 123]));
+        assert_eq!(event.action, "ban");
+        assert_eq!(event.source, "test");
+    }
+
+    #[test]
+    fn missing_victim_ip_errors() {
+        let adapter = basic_adapter();
+        let compiled = CompiledAdapter::compile(&adapter).unwrap();
+        let body = json!({ "alert_type": "udp_flood" });
+        let results = map_payload(&adapter, &compiled, &body);
+        assert!(matches!(
+            results.into_iter().next().unwrap(),
+            Err(MapError::MissingRequired("victim_ip"))
+        ));
+    }
+
+    #[test]
+    fn invalid_ip_errors() {
+        let adapter = basic_adapter();
+        let compiled = CompiledAdapter::compile(&adapter).unwrap();
+        let body = json!({ "target": { "ip": "not-an-ip" } });
+        let results = map_payload(&adapter, &compiled, &body);
+        assert!(matches!(
+            results.into_iter().next().unwrap(),
+            Err(MapError::InvalidIp(_))
+        ));
+    }
+
+    #[test]
+    fn root_path_produces_multiple_events() {
+        let mut adapter = basic_adapter();
+        adapter.root_path = Some("$.alerts[*]".into());
+        let compiled = CompiledAdapter::compile(&adapter).unwrap();
+        let body = json!({
+            "alerts": [
+                { "target": { "ip": "203.0.113.1" }, "alert_type": "udp_flood" },
+                { "target": { "ip": "203.0.113.2" }, "alert_type": "syn_flood" },
+                { "target": { "ip": "203.0.113.3" }, "alert_type": "icmp_flood" },
+            ]
+        });
+        let results = map_payload(&adapter, &compiled, &body);
+        assert_eq!(results.len(), 3);
+        let ips: Vec<_> = results.into_iter().map(|r| r.unwrap().victim_ip).collect();
+        assert_eq!(ips, vec!["203.0.113.1", "203.0.113.2", "203.0.113.3"]);
+    }
+
+    #[test]
+    fn vector_map_normalizes_values() {
+        let mut adapter = basic_adapter();
+        adapter
+            .vector_map
+            .insert("UDP_FLOOD".into(), "udp_flood".into());
+        adapter
+            .vector_map
+            .insert("TCP_SYN".into(), "syn_flood".into());
+        let compiled = CompiledAdapter::compile(&adapter).unwrap();
+        for (input, expected) in [
+            ("UDP_FLOOD", AttackVector::UdpFlood),
+            ("TCP_SYN", AttackVector::SynFlood),
+        ] {
+            let body = json!({ "target": { "ip": "203.0.113.9" }, "alert_type": input });
+            let results = map_payload(&adapter, &compiled, &body);
+            let event = results.into_iter().next().unwrap().unwrap();
+            assert_eq!(event.vector, expected, "input={input}");
+        }
+    }
+
+    #[test]
+    fn default_vector_fallback_when_not_mapped() {
+        let mut adapter = basic_adapter();
+        adapter.default_vector = Some("unknown".into());
+        let compiled = CompiledAdapter::compile(&adapter).unwrap();
+        let body = json!({ "target": { "ip": "203.0.113.9" }, "alert_type": "GARBAGE" });
+        let event = map_payload(&adapter, &compiled, &body)
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
+        assert_eq!(event.vector, AttackVector::Unknown);
+    }
+
+    #[test]
+    fn confidence_scaling_and_clamping() {
+        let mut adapter = basic_adapter();
+        adapter.confidence_scale = Some(100.0);
+        let compiled = CompiledAdapter::compile(&adapter).unwrap();
+        let body = json!({
+            "target": { "ip": "203.0.113.9" },
+            "score": 75,
+        });
+        let event = map_payload(&adapter, &compiled, &body)
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
+        assert_eq!(event.confidence, Some(0.75));
+
+        // Over-range value clamps to 1.0
+        let body = json!({ "target": { "ip": "203.0.113.9" }, "score": 500 });
+        let event = map_payload(&adapter, &compiled, &body)
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
+        assert_eq!(event.confidence, Some(1.0));
+    }
+
+    #[test]
+    fn source_id_prefix_applied() {
+        let mut adapter = basic_adapter();
+        adapter.source_id_prefix = Some("radware-".into());
+        let compiled = CompiledAdapter::compile(&adapter).unwrap();
+        let body = json!({
+            "id": "alert-7",
+            "target": { "ip": "203.0.113.9" },
+        });
+        let event = map_payload(&adapter, &compiled, &body)
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
+        assert_eq!(event.event_id.as_deref(), Some("radware-alert-7"));
+    }
+
+    #[test]
+    fn invalid_jsonpath_fails_compile() {
+        let mut adapter = basic_adapter();
+        adapter.fields.victim_ip = "not a path".into();
+        assert!(matches!(
+            CompiledAdapter::compile(&adapter),
+            Err(MapError::InvalidPath { .. })
+        ));
+    }
+
+    #[test]
+    fn hmac_verify_accepts_correct_signature() {
+        let secret = b"s3cret-key";
+        let body = br#"{"alerts":[{"id":1}]}"#;
+        let mut mac = HmacSha256::new_from_slice(secret).unwrap();
+        mac.update(body);
+        let sig = hex::encode(mac.finalize().into_bytes());
+        assert!(verify_hmac_sha256(secret, body, &sig));
+        assert!(verify_hmac_sha256(secret, body, &format!("sha256={sig}")));
+    }
+
+    #[test]
+    fn hmac_verify_rejects_wrong_signature() {
+        let secret = b"s3cret-key";
+        let body = br#"{"x":1}"#;
+        // Valid-length but wrong digest
+        let wrong = "0".repeat(64);
+        assert!(!verify_hmac_sha256(secret, body, &wrong));
+        // Mangled body
+        let mut mac = HmacSha256::new_from_slice(secret).unwrap();
+        mac.update(body);
+        let sig = hex::encode(mac.finalize().into_bytes());
+        assert!(!verify_hmac_sha256(secret, br#"{"x":2}"#, &sig));
+    }
+
+    #[test]
+    fn hmac_verify_rejects_malformed_hex() {
+        assert!(!verify_hmac_sha256(b"key", b"body", "not-hex!!"));
+        assert!(!verify_hmac_sha256(b"key", b"body", ""));
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -484,6 +484,7 @@ impl E2ETestContext {
             confidence_threshold,
             sources,
             default_weight: 1.0,
+            webhook_adapters: Vec::new(),
         };
 
         let state = AppState::new(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1911,6 +1911,7 @@ fn test_settings_with_correlation(
             m
         },
         default_weight: 1.0,
+        webhook_adapters: Vec::new(),
     };
     settings
 }
@@ -4708,4 +4709,271 @@ async fn test_openapi_includes_correlation_config() {
         schemas.contains_key("SourceConfig"),
         "OpenAPI spec should include SourceConfig schema"
     );
+}
+
+// =============================================================================
+// Generic webhook adapter integration tests
+// =============================================================================
+
+async fn setup_app_with_webhooks(
+    adapters: Vec<prefixd::correlation::WebhookAdapter>,
+) -> axum::Router {
+    let repo: Arc<dyn RepositoryTrait> = Arc::new(MockRepository::new());
+    let announcer = Arc::new(MockAnnouncer::new());
+    let settings = test_settings_with_correlation(true, 1, 0.5);
+
+    let state = AppState::new(
+        settings,
+        test_inventory(),
+        test_playbooks(),
+        repo,
+        announcer,
+        std::path::PathBuf::from("."),
+    )
+    .expect("failed to create app state");
+
+    {
+        let mut cfg = state.correlation_config.write().await;
+        cfg.webhook_adapters = adapters;
+    }
+
+    create_test_router(state)
+}
+
+fn basic_webhook_adapter(name: &str) -> prefixd::correlation::WebhookAdapter {
+    use prefixd::correlation::{WebhookAdapter, WebhookAuth, WebhookFieldMap};
+    WebhookAdapter {
+        name: name.to_string(),
+        description: "test".into(),
+        enabled: true,
+        auth: WebhookAuth::None,
+        root_path: None,
+        fields: WebhookFieldMap {
+            victim_ip: "$.ip".into(),
+            vector: Some("$.vector".into()),
+            timestamp: None,
+            bps: Some("$.bps".into()),
+            pps: Some("$.pps".into()),
+            confidence: Some("$.score".into()),
+            source_id: Some("$.id".into()),
+            top_dst_ports: None,
+            action: None,
+        },
+        vector_map: Default::default(),
+        default_vector: None,
+        confidence_scale: None,
+        source_id_prefix: None,
+    }
+}
+
+async fn post_webhook(
+    app: &axum::Router,
+    name: &str,
+    body: &str,
+    extra_headers: &[(&str, &str)],
+) -> (StatusCode, serde_json::Value) {
+    let mut req = Request::builder()
+        .method("POST")
+        .uri(format!("/v1/signals/webhook/{name}"))
+        .header("content-type", "application/json");
+    for (k, v) in extra_headers {
+        req = req.header(*k, *v);
+    }
+    let response = app
+        .clone()
+        .oneshot(req.body(Body::from(body.to_string())).unwrap())
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or(serde_json::json!({}));
+    (status, json)
+}
+
+#[tokio::test]
+async fn test_webhook_single_event_happy_path() {
+    let app = setup_app_with_webhooks(vec![basic_webhook_adapter("radware")]).await;
+    let body = r#"{
+        "id": "alert-1",
+        "ip": "203.0.113.5",
+        "vector": "udp_flood",
+        "bps": 100000,
+        "pps": 500,
+        "score": 0.9
+    }"#;
+    let (status, json) = post_webhook(&app, "radware", body, &[]).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["processed"], 1);
+    assert_eq!(json["failed"], 0);
+    assert_eq!(json["results"][0]["index"], 0);
+}
+
+#[tokio::test]
+async fn test_webhook_name_not_configured_returns_404() {
+    let app = setup_app_with_webhooks(vec![basic_webhook_adapter("radware")]).await;
+    let body = r#"{"ip":"203.0.113.5"}"#;
+    let (status, _json) = post_webhook(&app, "unknown", body, &[]).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_webhook_disabled_adapter_returns_404() {
+    let mut adapter = basic_webhook_adapter("radware");
+    adapter.enabled = false;
+    let app = setup_app_with_webhooks(vec![adapter]).await;
+    let body = r#"{"ip":"203.0.113.5"}"#;
+    let (status, _json) = post_webhook(&app, "radware", body, &[]).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_webhook_invalid_name_returns_404() {
+    let app = setup_app_with_webhooks(vec![]).await;
+    // Path traversal attempt
+    let body = r#"{}"#;
+    let (status, _json) = post_webhook(&app, "UPPER", body, &[]).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_webhook_missing_required_field_reports_error_in_result() {
+    let app = setup_app_with_webhooks(vec![basic_webhook_adapter("radware")]).await;
+    // Missing $.ip
+    let body = r#"{"vector":"udp_flood"}"#;
+    let (status, json) = post_webhook(&app, "radware", body, &[]).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["processed"], 0);
+    assert_eq!(json["failed"], 1);
+    assert_eq!(json["results"][0]["status"], "error");
+    let err = json["results"][0]["error"].as_str().unwrap();
+    assert!(
+        err.contains("victim_ip"),
+        "error should mention field: {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_webhook_root_path_iterates_batch() {
+    let mut adapter = basic_webhook_adapter("batchy");
+    adapter.root_path = Some("$.alerts[*]".into());
+    let app = setup_app_with_webhooks(vec![adapter]).await;
+    let body = r#"{
+        "alerts": [
+            {"id":"a","ip":"203.0.113.1","vector":"udp_flood"},
+            {"id":"b","ip":"203.0.113.2","vector":"syn_flood"},
+            {"id":"c","ip":"203.0.113.3","vector":"icmp_flood"}
+        ]
+    }"#;
+    let (status, json) = post_webhook(&app, "batchy", body, &[]).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["processed"], 3);
+    assert_eq!(json["failed"], 0);
+    assert_eq!(json["results"].as_array().unwrap().len(), 3);
+}
+
+#[tokio::test]
+async fn test_webhook_malformed_json_returns_400() {
+    let app = setup_app_with_webhooks(vec![basic_webhook_adapter("radware")]).await;
+    let body = r#"{not json"#;
+    let (status, _json) = post_webhook(&app, "radware", body, &[]).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_webhook_hmac_accepts_correct_signature() {
+    use hmac::Mac;
+    use prefixd::correlation::WebhookAuth;
+
+    // Use a random env var name to avoid parallel-test contention
+    let env_name = "PREFIXD_TEST_HMAC_SECRET_POS";
+    let secret = "super-secret";
+    // SAFETY: test-only; other tests use different env var names
+    unsafe { std::env::set_var(env_name, secret) };
+
+    let mut adapter = basic_webhook_adapter("signed");
+    adapter.auth = WebhookAuth::Hmac {
+        secret_env: env_name.into(),
+        header: "X-Signature-SHA256".into(),
+        algorithm: "sha256".into(),
+    };
+    let app = setup_app_with_webhooks(vec![adapter]).await;
+
+    let body = r#"{"ip":"203.0.113.5","vector":"udp_flood"}"#;
+    let mut mac =
+        <hmac::Hmac<sha2::Sha256> as hmac::Mac>::new_from_slice(secret.as_bytes()).unwrap();
+    mac.update(body.as_bytes());
+    let sig = hex::encode(mac.finalize().into_bytes());
+
+    let (status, json) = post_webhook(&app, "signed", body, &[("X-Signature-SHA256", &sig)]).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["processed"], 1);
+
+    unsafe { std::env::remove_var(env_name) };
+}
+
+#[tokio::test]
+async fn test_webhook_hmac_rejects_wrong_signature() {
+    use prefixd::correlation::WebhookAuth;
+
+    let env_name = "PREFIXD_TEST_HMAC_SECRET_NEG";
+    unsafe { std::env::set_var(env_name, "super-secret") };
+
+    let mut adapter = basic_webhook_adapter("signed2");
+    adapter.auth = WebhookAuth::Hmac {
+        secret_env: env_name.into(),
+        header: "X-Signature-SHA256".into(),
+        algorithm: "sha256".into(),
+    };
+    let app = setup_app_with_webhooks(vec![adapter]).await;
+
+    let body = r#"{"ip":"203.0.113.5","vector":"udp_flood"}"#;
+    let wrong_sig = "0".repeat(64);
+
+    let (status, _json) =
+        post_webhook(&app, "signed2", body, &[("X-Signature-SHA256", &wrong_sig)]).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+    unsafe { std::env::remove_var(env_name) };
+}
+
+#[tokio::test]
+async fn test_webhook_hmac_missing_header_returns_401() {
+    use prefixd::correlation::WebhookAuth;
+
+    let env_name = "PREFIXD_TEST_HMAC_SECRET_MISS";
+    unsafe { std::env::set_var(env_name, "super-secret") };
+
+    let mut adapter = basic_webhook_adapter("signed3");
+    adapter.auth = WebhookAuth::Hmac {
+        secret_env: env_name.into(),
+        header: "X-Signature-SHA256".into(),
+        algorithm: "sha256".into(),
+    };
+    let app = setup_app_with_webhooks(vec![adapter]).await;
+
+    let body = r#"{"ip":"203.0.113.5"}"#;
+    let (status, _json) = post_webhook(&app, "signed3", body, &[]).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+    unsafe { std::env::remove_var(env_name) };
+}
+
+#[tokio::test]
+async fn test_webhook_vector_map_and_scaling() {
+    let mut adapter = basic_webhook_adapter("scaled");
+    adapter.vector_map.insert("UDP".into(), "udp_flood".into());
+    adapter.confidence_scale = Some(100.0);
+    let app = setup_app_with_webhooks(vec![adapter]).await;
+
+    let body = r#"{
+        "id":"x",
+        "ip":"203.0.113.5",
+        "vector":"UDP",
+        "score":77
+    }"#;
+    let (status, json) = post_webhook(&app, "scaled", body, &[]).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["processed"], 1);
 }


### PR DESCRIPTION
## Summary

Adds a generic webhook adapter at `POST /v1/signals/webhook/{name}` so any detector or telemetry system that can POST JSON can be integrated without touching Rust. Operators declare adapters in \`correlation.yaml\` with JSONPath field mappings, HMAC/bearer/none auth, and optional array batching via \`root_path\`.

Design rationale in [ADR 020](docs/adr/020-generic-webhook-adapter.md); operator walkthrough in [docs/detectors/generic-webhook.md](docs/detectors/generic-webhook.md).

## Why

ADR 019 established dedicated Rust adapters per detector (Alertmanager, FastNetMon). That pattern doesn't scale to the long tail — commercial DDoS appliances (Radware, NETSCOUT, A10), cloud alerting (Cloud Armor, Shield), internal abuse systems. Operators shouldn't need to fork prefixd to wire in a new JSON detector.

## What's new

**Backend** (\`3b2d1c2\`)
- \`src/correlation/webhook.rs\` — adapter structs, \`CompiledAdapter\`, field mapper, HMAC-SHA256 verifier (constant-time via \`subtle\`), 13 unit tests
- \`CorrelationConfig.webhook_adapters\` with validation + redaction
- \`ingest_webhook\` handler + route + OpenAPI schema; 11 integration tests
- Example in \`configs/correlation.yaml\`, schema in \`docs/configuration.md\`, endpoint in \`docs/api.md\`
- New deps: \`serde_json_path 0.7\` (RFC 9535 JSONPath) and \`subtle 2\`

**Frontend** (\`0c67874\`)
- \`WebhookAdaptersEditor\` full CRUD on the Correlation Config tab
- Three auth modes, field-map editor, vector_map, root_path, confidence_scale
- 10 new Vitest validator tests

**Docs** (\`0c67874\`)
- ADR 020 — design rationale
- \`docs/detectors/generic-webhook.md\` — end-to-end Radware walkthrough, JSONPath cheat sheet, troubleshooting
- README, AGENTS.md, FEATURES.md, ROADMAP.md, ADR index all updated
- CHANGELOG Unreleased entry

## Auth

- **hmac** (recommended) — HMAC-SHA256 over the raw body, configurable header, constant-time compare, secret from env var named in \`auth.secret_env\` (never in YAML, never returned by API)
- **bearer** — reuses global session/bearer auth
- **none** — lab use only

## Safety

- Name validated against \`[a-z0-9-]{1,64}\` on the hot path (no path traversal)
- Disabled/unknown adapters return 404
- Partial failures in batched payloads reported per-event; overall status stays 2xx so senders don't retry
- Adapters hot-reload via \`POST /v1/config/reload\`

## Test results

- \`cargo fmt --check\` clean
- \`cargo clippy --all-targets -- -D warnings\` clean
- 196 unit + 110 integration + 16 postgres backend tests pass
- 78 frontend Vitest tests pass (10 new)
- \`bun run build\` clean