### PR TITLE
fix: security hardening, race conditions, and frontend bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ docs/
 ├── api.md                     # Full API reference with examples
 ├── deployment.md              # Docker + nginx deployment guide
 ├── configuration.md           # Full configuration reference
-└── adr/                       # 19 Architecture Decision Records (001-019)
+└── adr/                       # 22 Architecture Decision Records (001-022)
 grafana/                       # Prometheus config, Grafana provisioning, dashboard JSON
 tests/
 ├── integration.rs             # 99 integration tests (health, config, mitigations, events, filters, bulk withdraw, cursor pagination, bulk acknowledge, per-dest routing, preferences, event batch, incident reports, signal groups, correlation, signal adapters)
@@ -132,10 +132,18 @@ See `docs/adr/` for all 22 Architecture Decision Records.
 - `GET /metrics` - Prometheus metrics
 - `GET /openapi.json` - OpenAPI spec
 
+### Session & WebSocket (session auth)
+- `POST /v1/auth/logout` - End session
+- `GET /v1/auth/me` - Current operator profile
+- `GET /v1/ws/feed` - Real-time WebSocket feed (mitigation/event updates)
+
 ### Authenticated
 - `GET /v1/health/detail` - Full operational status (BGP peers, DB, uptime, active mitigations)
 - `POST /v1/events` - Ingest attack event
+- `POST /v1/events/batch` - Batch ingest up to 100 attack events
+- `GET /v1/events` - List events (cursor pagination, date range filters)
 - `GET /v1/mitigations` - List mitigations (supports `?status=active&customer_id=cust_123`)
+- `POST /v1/mitigations` - Create mitigation (manual "Mitigate Now")
 - `GET /v1/mitigations/{id}` - Get mitigation detail
 - `POST /v1/mitigations/withdraw` - Bulk withdraw mitigations (up to 100 IDs)
 - `POST /v1/mitigations/acknowledge` - Bulk acknowledge mitigations (up to 100 IDs)
@@ -143,7 +151,7 @@ See `docs/adr/` for all 22 Architecture Decision Records.
 - `GET/POST /v1/safelist` - List/add safelist entries
 - `DELETE /v1/safelist/{prefix}` - Remove safelist entry
 - `GET /v1/config/settings` - Running config (allowlist-redacted)
-- `GET /v1/config/inventory` - Customer/service/IP data
+- `POST /v1/config/reload` - Hot-reload inventory + playbooks + correlation + alerting
 - `GET /v1/config/playbooks` - Playbook definitions
 - `PUT /v1/config/playbooks` - Update playbooks (admin only, writes YAML + hot-reload)
 - `POST /v1/config/reload` - Hot-reload inventory + playbooks + alerting
@@ -154,6 +162,7 @@ See `docs/adr/` for all 22 Architecture Decision Records.
 - `PUT /v1/preferences` - Update notification preferences (muted events, quiet hours)
 - `GET /v1/stats` - Global statistics
 - `GET /v1/stats/timeseries` - Time-series data for charts
+- `GET /v1/reports/incident` - Incident report (mitigation + event summary)
 - `GET /v1/ip/{ip}/history` - IP history (events + mitigations + context)
 - `GET /v1/pops` - Points of presence
 - `GET /v1/audit` - Audit log

--- a/docs/api.md
+++ b/docs/api.md
@@ -1652,6 +1652,105 @@ Requires admin role.
 }
 ```
 
+### Correlation Config
+
+```http
+GET /v1/config/correlation
+Authorization: Bearer <token>
+```
+
+Returns the correlation engine configuration with secrets redacted. See the [Correlation](configuration.md#correlation) section for field semantics.
+
+**Response:**
+
+```json
+{
+  "config": {
+    "enabled": true,
+    "window_seconds": 300,
+    "min_sources": 1,
+    "confidence_threshold": 0.5,
+    "default_weight": 1.0,
+    "confidence_decay_half_life_seconds": 0,
+    "sources": {
+      "fastnetmon": {
+        "weight": 1.0,
+        "type": "detector",
+        "confidence_mapping": {},
+        "mode": "primary",
+        "match_dimensions": []
+      }
+    },
+    "webhook_adapters": [
+      {
+        "name": "radware",
+        "description": "Radware DefensePro",
+        "enabled": true,
+        "auth": {
+          "type": "hmac",
+          "secret_env": "RADWARE_WEBHOOK_SECRET",
+          "header": "X-Signature-SHA256",
+          "algorithm": "sha256"
+        },
+        "root_path": null,
+        "fields": {
+          "victim_ip": "$.target.ip",
+          "vector": "$.alert_type"
+        },
+        "vector_map": {},
+        "default_vector": "unknown",
+        "confidence_scale": null,
+        "source_id_prefix": null,
+        "transforms": {}
+      }
+    ]
+  },
+  "loaded_at": "2026-02-22T21:00:00Z"
+}
+```
+
+HMAC `secret_env` values are returned as-is (they name an environment variable, not a secret). No raw secret values are exposed.
+
+### Update Correlation Config
+
+```http
+PUT /v1/config/correlation
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "enabled": true,
+  "window_seconds": 300,
+  "min_sources": 2,
+  "confidence_threshold": 0.7,
+  "default_weight": 1.0,
+  "sources": {
+    "fastnetmon": { "weight": 1.0, "type": "detector", "mode": "primary" }
+  }
+}
+```
+
+**Admin only.** Validates the config, writes it to `correlation.yaml` (with `.bak` backup), and hot-reloads the in-memory correlation engine. Returns the updated config with secrets redacted.
+
+Validation rules (rejected with 400 on failure):
+- `window_seconds` must be > 0
+- `min_sources` must be >= 1
+- `confidence_threshold` must be between 0.0 and 1.0
+- `default_weight` must be >= 0.0
+- `confidence_decay_half_life_seconds` must be <= 10 × `window_seconds`
+- Per-source `mode=corroborating` requires a non-empty `match_dimensions`; `mode=primary` requires empty `match_dimensions`
+- Webhook adapter `name` must match `[a-z0-9-]{1,64}` and be unique
+
+**Response:** Same shape as `GET /v1/config/correlation`, with `loaded_at` set to the update timestamp.
+
+**Error response (400):**
+
+```json
+{
+  "errors": ["source 'router-cpu': match_dimensions must be non-empty when mode=corroborating"]
+}
+```
+
 ### List POPs
 
 ```http
@@ -1686,7 +1785,7 @@ POST /v1/config/reload
 
 ```json
 {
-  "reloaded": ["inventory", "playbooks", "alerting"],
+  "reloaded": ["inventory", "playbooks", "correlation", "alerting"],
   "timestamp": "2026-02-22T21:00:00Z"
 }
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -177,7 +177,15 @@ guardrails:
   # TTL bounds (optional overrides; if omitted, uses timers.min/max_ttl_seconds)
   min_ttl_seconds: 30
   max_ttl_seconds: 1800
+  
+  # FlowSpec match-type toggles (all default false)
+  allow_src_prefix_match: false
+  allow_tcp_flags_match: false
+  allow_fragment_match: false
+  allow_packet_length_match: false
 ```
+
+> **NOTE:** `allow_src_prefix_match`, `allow_tcp_flags_match`, `allow_fragment_match`, and `allow_packet_length_match` are parsed but not yet enforced. FlowSpec match types are currently limited to dst_prefix + protocol + ports.
 
 ### Quotas
 
@@ -226,12 +234,15 @@ timers:
 escalation:
   # Enable automatic escalation (police → discard)
   enabled: true
-  
+
   # Minimum time before escalation eligible
   min_persistence_seconds: 120
-  
+
   # Minimum confidence for escalation
   min_confidence: 0.7
+
+  # Maximum total duration for escalated mitigations (seconds, default: 1800)
+  max_escalated_duration_seconds: 1800
 ```
 
 ### Observability
@@ -589,6 +600,8 @@ assets:
     range_end: "203.0.113.110"  # 11 IPs
 ```
 
+> **NOTE:** This field is not yet implemented and will be silently ignored if specified.
+
 ### Policy Profiles
 
 | Profile | Thresholds | Escalation | TTLs |
@@ -628,6 +641,8 @@ match:
   protocol: udp        # Optional: protocol filter
 ```
 
+> **NOTE:** `source` and `protocol` are not yet implemented and will be silently ignored if specified. Only `vector` is currently used for playbook matching.
+
 ### Actions
 
 | Action | Parameters | Description |
@@ -660,6 +675,8 @@ steps:
 ### Default Playbook
 
 Fallback when no playbook matches:
+
+> **NOTE:** This field is not yet implemented and will be silently ignored if specified. Fallback behavior is handled by the built-in `unknown` playbook match.
 
 ```yaml
 default_playbook:
@@ -704,14 +721,14 @@ playbooks:
   # Amplification attacks: police only
   - name: dns_amp
     match:
-      vector: dns_amplification
+      vector: udp_flood
     steps:
       - action: police
         rate_bps: 50000000
         ttl_seconds: 120
 
   # Conservative fallback
-  - name: unknown
+  - name: unknown_conservative
     match:
       vector: unknown
     steps:

--- a/frontend/__tests__/use-auth.test.tsx
+++ b/frontend/__tests__/use-auth.test.tsx
@@ -12,6 +12,14 @@ vi.mock("@/lib/auth", () => ({
   logout: () => mockLogout(),
 }))
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}))
+
 import { AuthProvider, useAuth } from "@/hooks/use-auth"
 
 function wrapper({ children }: { children: ReactNode }) {

--- a/frontend/components/dashboard/mitigations-content-live.tsx
+++ b/frontend/components/dashboard/mitigations-content-live.tsx
@@ -232,12 +232,13 @@ export function MitigationsContentLive({ initialSearch, initialMitigateOpen }: M
         bulkWithdrawReason || "Bulk withdrawal",
         "dashboard"
       )
-      setBulkWithdrawOpen(false)
       setBulkWithdrawReason("")
       setSelectedIds(new Set())
       mutate()
       if (result.failed > 0) {
         setBulkWithdrawError(`${result.withdrawn} withdrawn, ${result.failed} failed`)
+      } else {
+        setBulkWithdrawOpen(false)
       }
     } catch (e) {
       setBulkWithdrawError(e instanceof Error ? e.message : "Bulk withdraw failed")

--- a/frontend/components/websocket-provider.tsx
+++ b/frontend/components/websocket-provider.tsx
@@ -92,7 +92,14 @@ export function WebSocketProvider({ children }: { children: React.ReactNode }) {
 
           // Handle ResyncRequired by invalidating SWR caches
           if (message.type === "ResyncRequired") {
-            mutate(() => true) // Revalidate all keys
+            mutate((key) =>
+              typeof key === "string" &&
+              (key.startsWith("mitigations") ||
+                key.startsWith("events") ||
+                key === "stats" ||
+                key === "dashboard" ||
+                key.startsWith("signal-groups"))
+            )
             if (showToast) toast.info("Configuration reloaded from disk")
           }
 
@@ -178,6 +185,17 @@ export function WebSocketProvider({ children }: { children: React.ReactNode }) {
       disconnect()
     }
   }, [connect, disconnect])
+
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (!document.hidden && wsRef.current?.readyState !== WebSocket.OPEN) {
+        reconnectAttemptsRef.current = 0
+        connect()
+      }
+    }
+    document.addEventListener("visibilitychange", handleVisibility)
+    return () => document.removeEventListener("visibilitychange", handleVisibility)
+  }, [connect])
 
   const value = useMemo(
     () => ({

--- a/frontend/hooks/use-auth.tsx
+++ b/frontend/hooks/use-auth.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect, useCallback, useMemo, createContext, useContext, type ReactNode } from "react"
+import { useRouter } from "next/navigation"
 import { type Operator, type LoginRequest, login as apiLogin, logout as apiLogout, getCurrentUser } from "@/lib/auth"
 
 interface AuthContextValue {
@@ -17,7 +18,7 @@ const AuthContext = createContext<AuthContextValue | null>(null)
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [operator, setOperator] = useState<Operator | null>(null)
   const [isLoading, setIsLoading] = useState(true)
-
+  const router = useRouter()
   const refresh = useCallback(async () => {
     try {
       const user = await getCurrentUser()
@@ -33,10 +34,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   // Clear operator on 401 from any API call (session expired)
   useEffect(() => {
-    const handleAuthExpired = () => setOperator(null)
+    const handleAuthExpired = () => {
+      setOperator(null)
+      router.push("/login")
+    }
     window.addEventListener("prefixd:auth-expired", handleAuthExpired)
     return () => window.removeEventListener("prefixd:auth-expired", handleAuthExpired)
-  }, [])
+  }, [router])
 
   const login = useCallback(async (credentials: LoginRequest) => {
     const user = await apiLogin(credentials)

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -166,7 +166,8 @@ async function doFetch<T>(url: string, options: RequestInit): Promise<T> {
     throw new Error(`API error ${res.status}: ${error}`)
   }
 
-  return res.json()
+  const text = await res.text()
+  return (text ? JSON.parse(text) : null) as T
 }
 
 export async function getHealth(): Promise<PublicHealthResponse> {

--- a/src/alerting/mod.rs
+++ b/src/alerting/mod.rs
@@ -371,7 +371,9 @@ impl DestinationConfig {
                 "api_key": "***",
                 "region": region,
             }),
-            Self::Generic { url, headers, .. } => {
+            Self::Generic {
+                url: _, headers, ..
+            } => {
                 let redacted_headers: HashMap<_, _> = headers
                     .keys()
                     .cloned()
@@ -379,7 +381,7 @@ impl DestinationConfig {
                     .collect();
                 serde_json::json!({
                     "type": "generic",
-                    "url": url,
+                    "url": "***",
                     "secret": "***",
                     "headers": redacted_headers,
                 })
@@ -757,18 +759,32 @@ impl AlertingConfig {
                 DestinationConfig::Generic { secret, url, .. } => {
                     if secret.as_deref() == Some(REDACTED) {
                         let u = url.clone();
-                        let matches: Vec<String> = current
-                            .destinations
-                            .iter()
-                            .filter_map(|d| match d {
-                                DestinationConfig::Generic {
-                                    secret: Some(s),
-                                    url: existing_url,
-                                    ..
-                                } if existing_url == &u => Some(s.clone()),
-                                _ => None,
-                            })
-                            .collect();
+                        let matches: Vec<String> = if u == REDACTED {
+                            // URL is also redacted — match by uniqueness among Generic destinations
+                            current
+                                .destinations
+                                .iter()
+                                .filter_map(|d| match d {
+                                    DestinationConfig::Generic {
+                                        secret: Some(s), ..
+                                    } => Some(s.clone()),
+                                    _ => None,
+                                })
+                                .collect()
+                        } else {
+                            current
+                                .destinations
+                                .iter()
+                                .filter_map(|d| match d {
+                                    DestinationConfig::Generic {
+                                        secret: Some(s),
+                                        url: existing_url,
+                                        ..
+                                    } if existing_url == &u => Some(s.clone()),
+                                    _ => None,
+                                })
+                                .collect()
+                        };
                         match matches.as_slice() {
                             [s] => *secret = Some(s.clone()),
                             [] => errors.push(format!(

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -1,10 +1,4 @@
-use axum::{
-    extract::{Request, State},
-    http::{StatusCode, header},
-    middleware::Next,
-    response::Response,
-};
-use std::sync::Arc;
+use axum::http::StatusCode;
 
 use crate::AppState;
 use crate::config::AuthMode;
@@ -135,91 +129,6 @@ pub fn require_role(
     }
 
     Err(StatusCode::UNAUTHORIZED)
-}
-
-/// Bearer token authentication middleware (legacy, for CLI/detectors only)
-pub async fn auth_middleware(
-    State(state): State<Arc<AppState>>,
-    request: Request,
-    next: Next,
-) -> Result<Response, StatusCode> {
-    match state.settings.http.auth.mode {
-        AuthMode::None => Ok(next.run(request).await),
-        AuthMode::Bearer => validate_bearer_token(&state, request, next).await,
-        AuthMode::Credentials => {
-            // Credentials mode uses session auth, handled by axum-login layer
-            // This middleware is for bearer-only routes, so reject here
-            Err(StatusCode::UNAUTHORIZED)
-        }
-        AuthMode::Mtls => {
-            // mTLS is handled at the transport layer, not here
-            // If we reach this point with mTLS configured, connection was already validated
-            Ok(next.run(request).await)
-        }
-    }
-}
-
-/// Bearer token authentication middleware for API routes
-/// Session-based auth is used only for WebSocket and /v1/auth/* endpoints
-pub async fn hybrid_auth_middleware(
-    State(state): State<Arc<AppState>>,
-    request: Request,
-    next: Next,
-) -> Result<Response, StatusCode> {
-    // If auth is disabled, allow all
-    if matches!(state.settings.http.auth.mode, AuthMode::None) {
-        return Ok(next.run(request).await);
-    }
-
-    // Check bearer token (CLI/detectors)
-    if let Some(auth_header) = request.headers().get(header::AUTHORIZATION) {
-        if let Ok(header_str) = auth_header.to_str() {
-            if header_str.starts_with("Bearer ") {
-                return validate_bearer_token(&state, request, next).await;
-            }
-        }
-    }
-
-    tracing::debug!("no valid session or bearer token");
-    Err(StatusCode::UNAUTHORIZED)
-}
-
-async fn validate_bearer_token(
-    state: &AppState,
-    request: Request,
-    next: Next,
-) -> Result<Response, StatusCode> {
-    // Use cached token from startup (avoids per-request env lookups)
-    let expected_token = match &state.bearer_token {
-        Some(token) => token.as_str(),
-        None => {
-            // Token was not loaded at startup - this is a configuration error
-            tracing::error!("bearer auth enabled but no token was loaded at startup");
-            return Err(StatusCode::INTERNAL_SERVER_ERROR);
-        }
-    };
-
-    // Extract Authorization header
-    let auth_header = request
-        .headers()
-        .get(header::AUTHORIZATION)
-        .and_then(|value| value.to_str().ok());
-
-    let provided_token = match auth_header {
-        Some(header) if header.starts_with("Bearer ") => &header[7..],
-        _ => {
-            tracing::warn!("missing or invalid Authorization header");
-            return Err(StatusCode::UNAUTHORIZED);
-        }
-    };
-
-    // Constant-time comparison to prevent timing attacks
-    if !constant_time_eq(provided_token.as_bytes(), expected_token.as_bytes()) {
-        tracing::warn!("invalid bearer token");
-        return Err(StatusCode::UNAUTHORIZED);
-    }
-
-    Ok(next.run(request).await)
 }
 
 /// Constant-time comparison to prevent timing attacks

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -380,6 +380,7 @@ fn validate_cidr(prefix: &str) -> Result<(), PrefixdError> {
 }
 
 #[derive(Deserialize)]
+#[allow(dead_code)]
 pub struct CreateMitigationRequest {
     operator_id: String,
     reason: String,
@@ -392,14 +393,14 @@ pub struct CreateMitigationRequest {
     rate_bps: Option<u64>,
     ttl_seconds: u32,
 }
-
 #[derive(Deserialize)]
+#[allow(dead_code)]
 pub struct WithdrawRequest {
     operator_id: String,
     reason: String,
 }
-
 #[derive(Deserialize)]
+#[allow(dead_code)]
 pub struct AddSafelistRequest {
     operator_id: String,
     prefix: String,
@@ -540,7 +541,9 @@ async fn handle_unban(
     // Store the unban event
     let source = input.source.clone();
     let unban_event = AttackEvent::from_input(input);
-    let _ = state.repo.insert_event(&unban_event).await;
+    if let Err(e) = state.repo.insert_event(&unban_event).await {
+        tracing::warn!(error = %e, "failed to insert unban event");
+    }
 
     // Withdraw from BGP (if not dry-run)
     if !state.is_dry_run() {
@@ -968,6 +971,10 @@ async fn handle_ban(
         }
     };
 
+    // Serialize mitigation creation to prevent TOCTOU race between
+    // find_active_by_scope and insert_mitigation.
+    let _mitigation_guard = state.mitigation_lock.lock().await;
+
     // Check for existing mitigation with same scope
     let scope_hash = intent.match_criteria.compute_scope_hash();
     if let Ok(Some(mut existing)) = state
@@ -1006,7 +1013,6 @@ async fn handle_ban(
         ));
     }
 
-    // Validate guardrails
     let guardrails = Guardrails::with_timers(
         state.settings.guardrails.clone(),
         state.settings.quotas.clone(),
@@ -1017,7 +1023,7 @@ async fn handle_ban(
         .repo
         .is_safelisted(&event.victim_ip)
         .await
-        .unwrap_or(false);
+        .map_err(AppError)?;
 
     if let Err(e) = guardrails
         .validate(&intent, state.repo.as_ref(), is_safelisted)
@@ -1080,11 +1086,12 @@ async fn handle_ban(
         .with_label_values(&[&mitigation.action_type.to_string(), &state.settings.pop])
         .inc();
 
-    // Resolve signal group to 'resolved' now that mitigation is confirmed
     if let Some(group_id) = signal_group_id {
         if let Ok(Some(mut group)) = state.repo.get_signal_group(group_id).await {
             group.status = crate::correlation::SignalGroupStatus::Resolved;
-            let _ = state.repo.update_signal_group(&group).await;
+            if let Err(e) = state.repo.update_signal_group(&group).await {
+                tracing::warn!(error = %e, group_id = %group.group_id, "failed to mark signal group resolved");
+            }
         }
     }
 
@@ -1203,7 +1210,8 @@ pub async fn list_audit(
     Query(query): Query<CursorQuery>,
 ) -> Result<Json<AuditListResponse>, StatusCode> {
     let auth_header = headers.get(AUTHORIZATION).and_then(|h| h.to_str().ok());
-    require_auth(&state, &auth_session, auth_header)?;
+    use crate::domain::OperatorRole;
+    let _operator = require_role(&state, &auth_session, auth_header, OperatorRole::Operator)?;
 
     let limit = clamp_limit(query.limit.unwrap_or(100));
     let cursor = query.cursor.as_deref().and_then(decode_cursor);
@@ -1456,7 +1464,9 @@ pub async fn create_mitigation(
 ) -> Result<impl IntoResponse, StatusCode> {
     // Check auth first
     let auth_header = headers.get(AUTHORIZATION).and_then(|h| h.to_str().ok());
-    require_auth(&state, &auth_session, auth_header)?;
+    use crate::domain::OperatorRole;
+    let operator = require_role(&state, &auth_session, auth_header, OperatorRole::Operator)?;
+    let operator_id = operator.username.clone();
 
     // Validate input
     if let Err(e) = validate_ip(&req.victim_ip) {
@@ -1465,7 +1475,7 @@ pub async fn create_mitigation(
     if let Err(e) = validate_string_len(&req.reason, "reason", MAX_STRING_LEN) {
         return Ok(AppError(e).into_response());
     }
-    if let Err(e) = validate_string_len(&req.operator_id, "operator_id", MAX_USERNAME_LEN) {
+    if let Err(e) = validate_string_len(&operator_id, "operator_id", MAX_USERNAME_LEN) {
         return Ok(AppError(e).into_response());
     }
 
@@ -1509,14 +1519,14 @@ pub async fn create_mitigation(
     let inventory = state.inventory.read().await;
     let customer_id = inventory.lookup_ip(&req.victim_ip).map(|c| c.customer_id);
     drop(inventory);
-
+    let prefix_len = if req.victim_ip.contains(':') { 128 } else { 32 };
     let intent = MitigationIntent {
         event_id: Uuid::new_v4(),
         customer_id,
         service_id: None,
         pop: state.settings.pop.clone(),
         match_criteria: MatchCriteria {
-            dst_prefix: format!("{}/32", req.victim_ip),
+            dst_prefix: format!("{}/{}", req.victim_ip, prefix_len),
             protocol,
             dst_ports: req.dst_ports,
         },
@@ -1534,11 +1544,10 @@ pub async fn create_mitigation(
         state.settings.quotas.clone(),
         &state.settings.timers,
     );
-    let is_safelisted = state
-        .repo
-        .is_safelisted(&req.victim_ip)
-        .await
-        .unwrap_or(false);
+    let is_safelisted = match state.repo.is_safelisted(&req.victim_ip).await {
+        Ok(v) => v,
+        Err(e) => return Ok(AppError(e).into_response()),
+    };
     if let Err(e) = guardrails
         .validate(&intent, state.repo.as_ref(), is_safelisted)
         .await
@@ -1600,11 +1609,11 @@ pub async fn withdraw_mitigation(
 ) -> Result<impl IntoResponse, StatusCode> {
     // Check auth
     let auth_header = headers.get(AUTHORIZATION).and_then(|h| h.to_str().ok());
-    require_auth(&state, &auth_session, auth_header)?;
+    use crate::domain::OperatorRole;
+    let operator = require_role(&state, &auth_session, auth_header, OperatorRole::Operator)?;
+    let operator_id = operator.username;
 
-    if req.operator_id.is_empty()
-        || validate_string_len(&req.operator_id, "operator_id", MAX_USERNAME_LEN).is_err()
-    {
+    if validate_string_len(&operator_id, "operator_id", MAX_USERNAME_LEN).is_err() {
         return Err(StatusCode::BAD_REQUEST);
     }
     if validate_string_len(&req.reason, "reason", MAX_STRING_LEN).is_err() {
@@ -1640,7 +1649,7 @@ pub async fn withdraw_mitigation(
     }
 
     let action_type_str = mitigation.action_type.to_string();
-    mitigation.withdraw(Some(format!("{}: {}", req.operator_id, req.reason)));
+    mitigation.withdraw(Some(format!("{}: {}", operator_id, req.reason)));
     state
         .repo
         .update_mitigation(&mitigation)
@@ -1670,7 +1679,7 @@ pub async fn withdraw_mitigation(
 
     tracing::info!(
         mitigation_id = %mitigation.mitigation_id,
-        operator = %req.operator_id,
+        operator = %operator_id,
         "mitigation withdrawn"
     );
 
@@ -1680,6 +1689,7 @@ pub async fn withdraw_mitigation(
 const MAX_BULK_WITHDRAW: usize = 100;
 
 #[derive(Deserialize, ToSchema)]
+#[allow(dead_code)]
 pub struct BulkWithdrawRequest {
     mitigation_ids: Vec<Uuid>,
     operator_id: String,
@@ -1717,14 +1727,14 @@ pub async fn bulk_withdraw_mitigations(
     Json(req): Json<BulkWithdrawRequest>,
 ) -> Result<Json<BulkWithdrawResponse>, StatusCode> {
     let auth_header = headers.get(AUTHORIZATION).and_then(|h| h.to_str().ok());
-    require_auth(&state, &auth_session, auth_header)?;
+    use crate::domain::OperatorRole;
+    let operator = require_role(&state, &auth_session, auth_header, OperatorRole::Operator)?;
+    let operator_id = operator.username;
 
     if req.mitigation_ids.is_empty() || req.mitigation_ids.len() > MAX_BULK_WITHDRAW {
         return Err(StatusCode::BAD_REQUEST);
     }
-    if req.operator_id.is_empty()
-        || validate_string_len(&req.operator_id, "operator_id", MAX_USERNAME_LEN).is_err()
-    {
+    if validate_string_len(&operator_id, "operator_id", MAX_USERNAME_LEN).is_err() {
         return Err(StatusCode::BAD_REQUEST);
     }
     if validate_string_len(&req.reason, "reason", MAX_STRING_LEN).is_err() {
@@ -1784,7 +1794,7 @@ pub async fn bulk_withdraw_mitigations(
             }
         }
 
-        mitigation.withdraw(Some(format!("{}: {}", req.operator_id, req.reason)));
+        mitigation.withdraw(Some(format!("{}: {}", operator_id, req.reason)));
         if let Err(e) = state.repo.update_mitigation(&mitigation).await {
             tracing::error!(error = %e, mitigation_id = %id, "DB update failed in bulk withdraw");
             failed += 1;
@@ -1817,7 +1827,7 @@ pub async fn bulk_withdraw_mitigations(
     }
 
     tracing::info!(
-        operator = %req.operator_id,
+        operator = %operator_id,
         withdrawn = withdrawn,
         failed = failed,
         total = req.mitigation_ids.len(),
@@ -1834,6 +1844,7 @@ pub async fn bulk_withdraw_mitigations(
 const MAX_BULK_ACKNOWLEDGE: usize = 100;
 
 #[derive(Deserialize, ToSchema)]
+#[allow(dead_code)]
 pub struct BulkAcknowledgeRequest {
     mitigation_ids: Vec<Uuid>,
     operator_id: String,
@@ -1871,20 +1882,20 @@ pub async fn bulk_acknowledge_mitigations(
     Json(req): Json<BulkAcknowledgeRequest>,
 ) -> Result<Json<BulkAcknowledgeResponse>, StatusCode> {
     let auth_header = headers.get(AUTHORIZATION).and_then(|h| h.to_str().ok());
-    require_auth(&state, &auth_session, auth_header)?;
+    use crate::domain::OperatorRole;
+    let operator = require_role(&state, &auth_session, auth_header, OperatorRole::Operator)?;
+    let operator_id = operator.username;
 
     if req.mitigation_ids.is_empty() || req.mitigation_ids.len() > MAX_BULK_ACKNOWLEDGE {
         return Err(StatusCode::BAD_REQUEST);
     }
-    if req.operator_id.is_empty()
-        || validate_string_len(&req.operator_id, "operator_id", MAX_USERNAME_LEN).is_err()
-    {
+    if validate_string_len(&operator_id, "operator_id", MAX_USERNAME_LEN).is_err() {
         return Err(StatusCode::BAD_REQUEST);
     }
 
     let acked_ids = state
         .repo
-        .acknowledge_mitigations(&req.mitigation_ids, &req.operator_id)
+        .acknowledge_mitigations(&req.mitigation_ids, &operator_id)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
@@ -1909,7 +1920,7 @@ pub async fn bulk_acknowledge_mitigations(
     let failed = req.mitigation_ids.len() as u32 - acknowledged;
 
     tracing::info!(
-        operator = %req.operator_id,
+        operator = %operator_id,
         acknowledged = acknowledged,
         failed = failed,
         total = req.mitigation_ids.len(),
@@ -2090,10 +2101,12 @@ pub async fn add_safelist(
     Json(req): Json<AddSafelistRequest>,
 ) -> Result<impl IntoResponse, StatusCode> {
     let auth_header = headers.get(AUTHORIZATION).and_then(|h| h.to_str().ok());
-    require_auth(&state, &auth_session, auth_header)?;
+    use crate::domain::OperatorRole;
+    let operator = require_role(&state, &auth_session, auth_header, OperatorRole::Admin)?;
+    let operator_id = operator.username;
 
     validate_cidr(&req.prefix).map_err(|_| StatusCode::BAD_REQUEST)?;
-    validate_string_len(&req.operator_id, "operator_id", MAX_USERNAME_LEN)
+    validate_string_len(&operator_id, "operator_id", MAX_USERNAME_LEN)
         .map_err(|_| StatusCode::BAD_REQUEST)?;
     if let Some(ref reason) = req.reason {
         validate_string_len(reason, "reason", MAX_STRING_LEN)
@@ -2102,11 +2115,11 @@ pub async fn add_safelist(
 
     state
         .repo
-        .insert_safelist(&req.prefix, &req.operator_id, req.reason.as_deref())
+        .insert_safelist(&req.prefix, &operator_id, req.reason.as_deref())
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    tracing::info!(prefix = %req.prefix, operator = %req.operator_id, "safelist entry added");
+    tracing::info!(prefix = %req.prefix, operator = %operator_id, "safelist entry added");
     Ok(StatusCode::CREATED)
 }
 
@@ -2117,7 +2130,8 @@ pub async fn remove_safelist(
     Path(prefix): Path<String>,
 ) -> Result<impl IntoResponse, StatusCode> {
     let auth_header = headers.get(AUTHORIZATION).and_then(|h| h.to_str().ok());
-    require_auth(&state, &auth_session, auth_header)?;
+    use crate::domain::OperatorRole;
+    let _operator = require_role(&state, &auth_session, auth_header, OperatorRole::Admin)?;
 
     let removed = state
         .repo
@@ -2259,7 +2273,8 @@ pub async fn reload_config(
     headers: HeaderMap,
 ) -> Result<impl IntoResponse, StatusCode> {
     let auth_header = headers.get(AUTHORIZATION).and_then(|h| h.to_str().ok());
-    require_auth(&state, &auth_session, auth_header)?;
+    use crate::domain::OperatorRole;
+    let _operator = require_role(&state, &auth_session, auth_header, OperatorRole::Admin)?;
 
     match state.reload_config().await {
         Ok(reloaded) => {
@@ -2498,6 +2513,7 @@ pub struct CreateOperatorRequest {
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct ChangePasswordRequest {
+    pub current_password: String,
     pub new_password: String,
 }
 
@@ -2711,7 +2727,7 @@ pub async fn change_password(
     use super::auth::require_role;
     use crate::domain::OperatorRole;
     use argon2::{
-        Argon2, PasswordHasher,
+        Argon2, PasswordHash, PasswordHasher, PasswordVerifier,
         password_hash::{SaltString, rand_core::OsRng},
     };
 
@@ -2739,6 +2755,18 @@ pub async fn change_password(
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
         .ok_or(StatusCode::NOT_FOUND)?;
+
+    // Verify current password
+    let parsed_hash = match PasswordHash::new(&target.password_hash) {
+        Ok(h) => h,
+        Err(_) => return Err(StatusCode::INTERNAL_SERVER_ERROR),
+    };
+    if Argon2::default()
+        .verify_password(req.current_password.as_bytes(), &parsed_hash)
+        .is_err()
+    {
+        return Err(StatusCode::BAD_REQUEST);
+    }
 
     // Hash new password
     let salt = SaltString::generate(&mut OsRng);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -6,7 +6,7 @@ pub mod ratelimit;
 mod request_id;
 mod routes;
 
-pub use auth::{auth_middleware, hybrid_auth_middleware, require_auth};
+pub use auth::require_auth;
 pub use openapi::ApiDoc;
 pub use ratelimit::RateLimiter;
 pub use routes::*;

--- a/src/api/ratelimit.rs
+++ b/src/api/ratelimit.rs
@@ -1,6 +1,6 @@
 use axum::{
     Json,
-    extract::Request,
+    extract::{Request, State},
     http::StatusCode,
     middleware::Next,
     response::{IntoResponse, Response},
@@ -58,7 +58,7 @@ impl RateLimiter {
 
 /// Rate limiting middleware
 pub async fn rate_limit_middleware(
-    limiter: Arc<RateLimiter>,
+    State(limiter): State<Arc<RateLimiter>>,
     request: Request,
     next: Next,
 ) -> Response {

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -12,7 +12,11 @@ use tower_http::set_header::SetResponseHeaderLayer;
 use tower_sessions_sqlx_store::PostgresStore;
 use utoipa::OpenApi;
 
-use super::{handlers, openapi::ApiDoc};
+use super::{
+    handlers,
+    openapi::ApiDoc,
+    ratelimit::{RateLimiter, rate_limit_middleware},
+};
 use crate::AppState;
 use crate::auth::AuthBackend;
 use crate::ws;
@@ -133,8 +137,8 @@ fn api_routes() -> Router<Arc<AppState>> {
 }
 
 /// Common layers applied to both production and test routers
-fn common_layers(router: Router) -> Router {
-    router
+fn common_layers(router: Router, state: &AppState) -> Router {
+    let router = router
         .layer(axum::middleware::from_fn(super::request_id::request_id))
         .layer(axum::middleware::from_fn(super::metrics::http_metrics))
         .layer(SetResponseHeaderLayer::overriding(
@@ -149,7 +153,14 @@ fn common_layers(router: Router) -> Router {
             header::CACHE_CONTROL,
             HeaderValue::from_static("no-store"),
         ))
-        .layer(RequestBodyLimitLayer::new(1024 * 1024))
+        .layer(RequestBodyLimitLayer::new(1024 * 1024));
+
+    // Apply rate limiting middleware (always configured — RateLimitConfig has defaults)
+    let limiter = RateLimiter::new(state.settings.http.rate_limit.clone());
+    router.layer(axum::middleware::from_fn_with_state(
+        limiter,
+        rate_limit_middleware,
+    ))
 }
 
 /// Create the production router with PostgreSQL session store
@@ -163,9 +174,12 @@ pub fn create_router(
         .layer(auth_layer)
         .with_state(state.clone());
 
-    common_layers(router).layer(if let Some(ref origin) = state.settings.http.cors_origin {
+    common_layers(router, &state).layer(if let Some(origin) = &state.settings.http.cors_origin {
         CorsLayer::new()
-            .allow_origin(origin.parse::<HeaderValue>().expect("invalid cors_origin"))
+            .allow_origin(origin.parse::<HeaderValue>().unwrap_or_else(|_| {
+                tracing::warn!(origin = %origin, "invalid cors_origin, falling back to wildcard");
+                HeaderValue::from_static("*")
+            }))
             .allow_methods([Method::GET, Method::POST, Method::DELETE, Method::OPTIONS])
             .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION, header::COOKIE])
             .allow_credentials(true)
@@ -193,5 +207,5 @@ pub fn create_test_router(state: Arc<AppState>) -> Router {
         .layer(auth_layer)
         .with_state(state.clone());
 
-    common_layers(router)
+    common_layers(router, &state)
 }

--- a/src/auth/backend.rs
+++ b/src/auth/backend.rs
@@ -1,13 +1,25 @@
-use argon2::{Argon2, PasswordHash, PasswordVerifier};
+use argon2::{Argon2, PasswordHash, PasswordHasher, PasswordVerifier};
 use axum_login::{AuthUser, AuthnBackend, UserId};
 use serde::Deserialize;
 use std::sync::Arc;
+use std::sync::LazyLock;
 use uuid::Uuid;
 
 use crate::db::RepositoryTrait;
 use crate::domain::Operator;
 
-/// Credentials for login
+static DUMMY_HASH: LazyLock<String> = LazyLock::new(|| {
+    Argon2::default()
+        .hash_password(
+            b"dummy-password-not-a-real-password",
+            &argon2::password_hash::SaltString::generate(
+                &mut argon2::password_hash::rand_core::OsRng,
+            ),
+        )
+        .map(|h| h.to_string())
+        .unwrap_or_default()
+});
+
 #[derive(Clone, Deserialize)]
 pub struct Credentials {
     pub username: String,
@@ -57,6 +69,11 @@ impl AuthnBackend for AuthBackend {
         let operator = match self.repo.get_operator_by_username(&creds.username).await {
             Ok(Some(op)) => op,
             Ok(None) => {
+                // Run dummy Argon2 verify to prevent timing-based username enumeration
+                if let Ok(dummy_hash) = PasswordHash::new(&DUMMY_HASH) {
+                    let _ =
+                        Argon2::default().verify_password(creds.password.as_bytes(), &dummy_hash);
+                }
                 tracing::debug!(username = %creds.username, "operator not found");
                 return Ok(None);
             }

--- a/src/correlation/config.rs
+++ b/src/correlation/config.rs
@@ -502,6 +502,7 @@ impl CorrelationConfig {
                     "default_vector": a.default_vector,
                     "confidence_scale": a.confidence_scale,
                     "source_id_prefix": a.source_id_prefix,
+                    "transforms": a.transforms,
                 })
             })
             .collect();

--- a/src/guardrails/mod.rs
+++ b/src/guardrails/mod.rs
@@ -21,6 +21,19 @@ impl Guardrails {
         quotas: QuotasConfig,
         timers: &TimersConfig,
     ) -> Self {
+        if !config.allow_src_prefix_match
+            || !config.allow_tcp_flags_match
+            || !config.allow_fragment_match
+            || !config.allow_packet_length_match
+        {
+            tracing::warn!(
+                allow_src_prefix = config.allow_src_prefix_match,
+                allow_tcp_flags = config.allow_tcp_flags_match,
+                allow_fragment = config.allow_fragment_match,
+                allow_packet_length = config.allow_packet_length_match,
+                "guardrail allow_* flags are configured but not yet enforced; FlowSpec match types are limited to dst_prefix+protocol+ports"
+            );
+        }
         let min_ttl = config.min_ttl_seconds.unwrap_or(timers.min_ttl_seconds);
         let max_ttl = config.max_ttl_seconds.unwrap_or(timers.max_ttl_seconds);
         Self {

--- a/src/state.rs
+++ b/src/state.rs
@@ -42,7 +42,11 @@ pub struct AppState {
     pub correlation_loaded_at: RwLock<DateTime<Utc>>,
     /// PostgreSQL pool for metrics (None in tests with MockRepository)
     pub db_pool: Option<PgPool>,
-    config_dir: PathBuf,
+    /// Serializes mitigation creation to prevent TOCTOU race between
+    /// find_active_by_scope and insert_mitigation in handle_ban.
+    pub mitigation_lock: tokio::sync::Mutex<()>,
+    /// Directory containing config files (for hot-reload)
+    pub config_dir: PathBuf,
     shutting_down: AtomicBool,
 }
 
@@ -116,6 +120,7 @@ impl AppState {
             start_time: Instant::now(),
             inventory_loaded_at: RwLock::new(Utc::now()),
             playbooks_loaded_at: RwLock::new(Utc::now()),
+            mitigation_lock: tokio::sync::Mutex::new(()),
             db_pool,
             config_dir,
             shutting_down: AtomicBool::new(false),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6552,3 +6552,805 @@ async fn test_cache_listing_endpoint_source_filter_scopes_aggregates() {
     assert_eq!(by_source[0]["source"], "pop-utilization");
     assert_eq!(by_source[0]["count"], 1);
 }
+
+// ==========================================================================
+// Integration tests for untested API endpoints
+// ==========================================================================
+
+// ─── Operators CRUD ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_list_operators() {
+    let app = setup_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/operators")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["count"], 0);
+    assert!(json["operators"].is_array());
+}
+
+#[tokio::test]
+async fn test_create_operator() {
+    let app = setup_app().await;
+
+    let body = serde_json::json!({
+        "username": "newadmin",
+        "password": "supersecret",
+        "role": "admin"
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/operators")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let resp_body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+    assert_eq!(json["username"], "newadmin");
+    assert_eq!(json["role"], "admin");
+}
+
+#[tokio::test]
+async fn test_create_operator_duplicate() {
+    let app = setup_app().await;
+
+    let body = serde_json::json!({
+        "username": "dupadmin",
+        "password": "supersecret",
+        "role": "admin"
+    });
+
+    // First create succeeds
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/operators")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    // Second create with same username fails with 409
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/operators")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn test_delete_operator() {
+    let app = setup_app().await;
+
+    // Create an operator to delete
+    let create_body = serde_json::json!({
+        "username": "delete_me",
+        "password": "supersecret",
+        "role": "admin"
+    });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/operators")
+                .header("content-type", "application/json")
+                .body(Body::from(create_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let resp_body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+    let operator_id = json["operator_id"].as_str().unwrap();
+
+    // Delete the operator
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/v1/operators/{}", operator_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn test_delete_operator_not_found() {
+    let app = setup_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/v1/operators/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_change_password() {
+    let app = setup_app().await;
+
+    // Create an operator
+    let create_body = serde_json::json!({
+        "username": "pwd_user",
+        "password": "supersecret",
+        "role": "admin"
+    });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/operators")
+                .header("content-type", "application/json")
+                .body(Body::from(create_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let resp_body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+    let operator_id = json["operator_id"].as_str().unwrap();
+
+    // Change password
+    let pwd_body = serde_json::json!({
+        "current_password": "supersecret",
+        "new_password": "newsupersecret"
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/v1/operators/{}/password", operator_id))
+                .header("content-type", "application/json")
+                .body(Body::from(pwd_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+}
+
+// ─── Safelist CRUD ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_list_safelist() {
+    let app = setup_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/safelist")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(json.is_array());
+}
+
+#[tokio::test]
+async fn test_add_safelist() {
+    let app = setup_app().await;
+
+    let body = serde_json::json!({
+        "operator_id": "test_operator",
+        "prefix": "198.51.100.0/24",
+        "reason": "test safelist"
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/safelist")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+}
+
+#[tokio::test]
+async fn test_add_safelist_invalid_prefix() {
+    let app = setup_app().await;
+
+    let body = serde_json::json!({
+        "operator_id": "test_operator",
+        "prefix": "not-a-valid-cidr"
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/safelist")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_remove_safelist() {
+    let app = setup_app().await;
+
+    // Add a safelist entry first
+    let add_body = serde_json::json!({
+        "operator_id": "test_operator",
+        "prefix": "198.51.100.1"
+    });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/safelist")
+                .header("content-type", "application/json")
+                .body(Body::from(add_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    // Remove it
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/v1/safelist/198.51.100.1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn test_remove_safelist_not_found() {
+    let app = setup_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/v1/safelist/198.51.100.1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+// ─── Manual mitigate ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_create_mitigation() {
+    let app = setup_app().await;
+
+    let body = serde_json::json!({
+        "operator_id": "test_operator",
+        "reason": "manual mitigation",
+        "victim_ip": "203.0.113.10",
+        "protocol": "udp",
+        "dst_ports": [53],
+        "action": "discard",
+        "ttl_seconds": 120
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/mitigations")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+}
+
+#[tokio::test]
+async fn test_create_mitigation_safelisted() {
+    let app = setup_app().await;
+
+    // Safelist the victim IP first
+    let safelist_body = serde_json::json!({
+        "operator_id": "test_operator",
+        "prefix": "203.0.113.10/32"
+    });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/safelist")
+                .header("content-type", "application/json")
+                .body(Body::from(safelist_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    // Attempt to mitigate the safelisted IP
+    let body = serde_json::json!({
+        "operator_id": "test_operator",
+        "reason": "manual mitigation",
+        "victim_ip": "203.0.113.10",
+        "protocol": "udp",
+        "dst_ports": [53],
+        "action": "discard",
+        "ttl_seconds": 120
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/mitigations")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
+async fn test_create_mitigation_invalid_ip() {
+    let app = setup_app().await;
+
+    let body = serde_json::json!({
+        "operator_id": "test_operator",
+        "reason": "manual mitigation",
+        "victim_ip": "not-an-ip",
+        "protocol": "udp",
+        "action": "discard",
+        "ttl_seconds": 120
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/mitigations")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_create_mitigation_invalid_protocol() {
+    let app = setup_app().await;
+
+    let body = serde_json::json!({
+        "operator_id": "test_operator",
+        "reason": "manual mitigation",
+        "victim_ip": "203.0.113.10",
+        "protocol": "gre",
+        "action": "discard",
+        "ttl_seconds": 120
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/mitigations")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_create_mitigation_police_no_rate() {
+    let app = setup_app().await;
+
+    let body = serde_json::json!({
+        "operator_id": "test_operator",
+        "reason": "manual mitigation",
+        "victim_ip": "203.0.113.10",
+        "protocol": "udp",
+        "action": "police",
+        "ttl_seconds": 120
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/mitigations")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+// ─── Audit log ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_list_audit() {
+    let app = setup_app().await;
+
+    // Ingest an event to generate an audit entry
+    let event_json = r#"{
+        "timestamp": "2026-01-16T14:00:00Z",
+        "source": "test",
+        "victim_ip": "203.0.113.10",
+        "vector": "udp_flood",
+        "pps": 50000
+    }"#;
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/events")
+                .header("content-type", "application/json")
+                .body(Body::from(event_json))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/audit")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(json["count"].as_u64().is_some() || json["entries"].is_array());
+}
+
+#[tokio::test]
+async fn test_list_audit_empty() {
+    let app = setup_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/audit")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["count"], 0);
+    assert_eq!(json["entries"].as_array().unwrap().len(), 0);
+}
+
+// ─── Stats ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_get_stats() {
+    let app = setup_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/stats")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(json["total_active"].is_number());
+    assert!(json["total_mitigations"].is_number());
+    assert!(json["total_events"].is_number());
+    assert!(json["pops"].is_array());
+}
+
+// ─── Auth ──────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_get_me() {
+    let app = setup_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/auth/me")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Auth mode is None, but get_me uses auth_session.user directly (no
+    // require_auth). With no session, expect 401.
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_logout() {
+    let app = setup_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/auth/logout")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+// ─── Single mitigation withdraw ────────────────────────────────────────
+
+#[tokio::test]
+async fn test_withdraw_single_mitigation() {
+    let app = setup_app().await;
+
+    // Ingest an event to create a mitigation
+    let event_json = r#"{
+        "timestamp": "2026-01-16T14:00:00Z",
+        "source": "test",
+        "victim_ip": "203.0.113.10",
+        "vector": "udp_flood",
+        "pps": 50000
+    }"#;
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/events")
+                .header("content-type", "application/json")
+                .body(Body::from(event_json))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+    // Get the mitigation ID
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/v1/mitigations")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let mitigations = json["mitigations"].as_array().unwrap();
+    assert!(!mitigations.is_empty());
+    let mitigation_id = mitigations[0]["mitigation_id"].as_str().unwrap();
+
+    // Withdraw it
+    let withdraw_body = serde_json::json!({
+        "operator_id": "test_operator",
+        "reason": "manual withdraw"
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/mitigations/{}/withdraw", mitigation_id))
+                .header("content-type", "application/json")
+                .body(Body::from(withdraw_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_withdraw_nonexistent_mitigation() {
+    let app = setup_app().await;
+
+    let withdraw_body = serde_json::json!({
+        "operator_id": "test_operator",
+        "reason": "withdraw nonexistent"
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/mitigations/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/withdraw")
+                .header("content-type", "application/json")
+                .body(Body::from(withdraw_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+// ─── Event ingestion edge cases ────────────────────────────────────────
+
+#[tokio::test]
+async fn test_ingest_event_malformed_json() {
+    let app = setup_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/events")
+                .header("content-type", "application/json")
+                .body(Body::from("{ this is not valid json"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_ingest_event_missing_victim_ip() {
+    let app = setup_app().await;
+
+    let event_json = r#"{
+        "timestamp": "2026-01-16T14:00:00Z",
+        "source": "test",
+        "vector": "udp_flood",
+        "pps": 50000
+    }"#;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/events")
+                .header("content-type", "application/json")
+                .body(Body::from(event_json))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
+async fn test_ingest_event_unknown_vector() {
+    let app = setup_app().await;
+
+    // "unknown" is a valid AttackVector variant (deserializes) but matches
+    // no playbook, so the event is accepted with status accepted_no_playbook.
+    let event_json = r#"{
+        "timestamp": "2026-01-16T14:00:00Z",
+        "source": "test",
+        "victim_ip": "203.0.113.10",
+        "vector": "unknown",
+        "pps": 50000
+    }"#;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/events")
+                .header("content-type", "application/json")
+                .body(Body::from(event_json))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["status"], "accepted_no_playbook");
+    assert!(json["mitigation_id"].is_null());
+}


### PR DESCRIPTION
## Summary

Fanned out 5 scout agents to audit the codebase, found 4 critical, 11 high, and 20+ medium issues across security, reliability, and docs. Fixed all with 5 parallel worker agents, then repaired integration issues and verified.

## Critical Fixes

- **`res.json()` on empty-body responses** — `doFetch()` unconditionally called `res.json()` on 201/204 responses with no body, breaking safelist add/remove, notification preferences, password change, and operator delete
- **Rate limiting dead code** — `RateLimiter` fully implemented but never wired into router; all API endpoints had zero rate limiting
- **TOCTOU race in `handle_ban`** — `find_active_by_scope` + `insert_mitigation` non-atomic; concurrent ban events for same victim created duplicate FlowSpec announcements. Added `mitigation_lock: Mutex<()>`
- **Safelist check fail-open** — `.unwrap_or(false)` on DB error returned "not safelisted", allowing mitigation for safelisted infrastructure IPs. Now fails closed

## Security Fixes

- **Login timing attack** — user-not-found returned immediately without Argon2; now runs dummy verify to prevent username enumeration
- **Operator ID IDOR** — 5 mutation handlers accepted `operator_id` from request body without verifying against session. Now uses authenticated operator's username
- **Safelist ops lack role enforcement** — `add_safelist`/`remove_safelist` used `require_auth()` instead of `require_role(Admin)`. Viewers could disable DDoS protection for arbitrary IPs
- **`change_password` missing current password verification** — compromised session could change password for persistent access
- **`reload_config` and `list_audit` lack role enforcement** — any authenticated user could trigger reload or read audit logs
- **CORS panic** — `.expect("invalid cors_origin")` crashed on bad config; now falls back to wildcard with warning
- **Generic alerting URL not redacted** — internal webhook endpoints exposed to any authenticated user
- **Dead auth middleware removed** — `auth_middleware`/`hybrid_auth_middleware` never wired into router

## Backend Fixes

- IPv6 `/32` prefix bug in `create_mitigation` — now uses `/128` for IPv6
- Silent error swallowing on unban event insertion — now logs warning
- Signal group resolution error swallowed — now logs warning
- Warning log for unenforced guardrail `allow_*` config flags

## Frontend Fixes

- WebSocket permanent death after 10 reconnects — visibilitychange listener resets counter
- Auth-expired event doesn't redirect to `/login` — now calls `router.push`
- SWR `mutate(() => true)` thundering herd — scoped to volatile keys only
- Bulk withdraw error displayed after dialog closes — dialog stays open on partial failure

## Docs/Config Fixes

- Added missing API docs for `GET/PUT /v1/config/correlation`
- Updated AGENTS.md endpoint list (7 missing endpoints) and ADR count (19→22)
- Annotated 4 phantom config fields as unimplemented (`range_end`, `match.source`, `match.protocol`, `default_playbook`)
- Documented `max_escalated_duration_seconds` and guardrail `allow_*` flags
- Fixed reload response example (missing "correlation")
- Fixed playbook example vector (`dns_amplification` → `udp_flood`)
- Added `transforms` field to correlation config redacted output

## Tests

- 22 new integration tests: operators CRUD (6), safelist CRUD (5), manual mitigate (5), audit log (2), stats (1), auth (2), single withdraw (2), event edge cases (3)

## Verification

- `cargo test --features test-utils` — 425 tests pass (250 unit + 159 integration + 16 postgres)
- `cargo clippy -- -D warnings` — clean
- `cargo fmt --check` — clean
- `bun run build` — clean
- `bun run test` — 87 tests pass (11 files)